### PR TITLE
Performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ Makefile
 Makefile.*
 *.mk
 cmake_install.cmake
+config.ini
+hft_server
+hft_trader
+libhft_common.a
+server_config.ini
+trader_config.ini

--- a/common/src/event_fd.hpp
+++ b/common/src/event_fd.hpp
@@ -1,0 +1,56 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-02-13
+ */
+
+#ifndef HFT_COMMON_CONDITIONVARIABLE_HPP
+#define HFT_COMMON_CONDITIONVARIABLE_HPP
+
+#include <atomic>
+#include <spdlog/spdlog.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+namespace hft {
+
+/**
+ * @brief Lightweight condition variable to wake up threads
+ */
+class EventFd {
+public:
+  EventFd() : mEfd{eventfd(0, EFD_NONBLOCK)} {
+    if (mEfd == -1) {
+      throw std::runtime_error("Failed to create eventfd");
+    }
+  }
+  ~EventFd() {
+    notify();
+    close(mEfd);
+  }
+
+  void wait() {
+    mWaiting.store(true);
+    uint64_t val;
+    if (read(mEfd, &val, sizeof(val)) == -1) {
+      spdlog::error("Failed to read from eventfd");
+    }
+  }
+
+  void notify() {
+    if (!mWaiting.load()) {
+      return;
+    }
+    uint64_t val{1};
+    if (write(mEfd, &val, sizeof(val)) == -1) {
+      spdlog::error("Failed to write to eventfd");
+    }
+  }
+
+private:
+  const int mEfd;
+  std::atomic_bool mWaiting;
+};
+
+} // namespace hft
+
+#endif // HFT_COMMON_CONDITIONVARIABLE_HPP

--- a/common/src/network/async_socket.hpp
+++ b/common/src/network/async_socket.hpp
@@ -180,7 +180,7 @@ private:
       mHead = 0;
     }
     if (!mMessageBuffer.empty()) {
-      mSink.dataSink.post(mMessageBuffer);
+      mSink.dataSink.post(Span<MessageIn>(mMessageBuffer));
     }
     mMessageBuffer.clear();
     asyncRead();

--- a/common/src/network/async_socket.hpp
+++ b/common/src/network/async_socket.hpp
@@ -12,6 +12,7 @@
 #include <spdlog/spdlog.h>
 #include <vector>
 
+#include "constants.hpp"
 #include "network_types.hpp"
 #include "types.hpp"
 #include "utils/string_utils.hpp"

--- a/common/src/rtt_tracker.hpp
+++ b/common/src/rtt_tracker.hpp
@@ -27,6 +27,9 @@ struct RttStats {
   std::vector<RttRangeSample> samples{SAMPLES_SIZE};
 };
 
+/**
+ * @brief HdrHistogram at home
+ */
 class RttTracker {
   struct alignas(64) GlobalSample {
     std::atomic_uint64_t sum;

--- a/common/src/sink/command_sink.hpp
+++ b/common/src/sink/command_sink.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <map>
 
+#include "template_types.hpp"
 #include "utils/utils.hpp"
 
 namespace hft {

--- a/common/src/sink/command_sink.hpp
+++ b/common/src/sink/command_sink.hpp
@@ -61,7 +61,7 @@ public:
 private:
   template <typename EventType>
   std::vector<CRefHandler<EventType>> &getEventHandlers() {
-    constexpr auto index = utils::getTypeIndex<EventType, EventTypes...>();
+    constexpr auto index = getTypeIndex<EventType, EventTypes...>();
     return std::get<index>(mEventHandlers);
   }
 

--- a/common/src/sink/hybrid_io_sink.hpp
+++ b/common/src/sink/hybrid_io_sink.hpp
@@ -1,0 +1,125 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-02-13
+ */
+
+#ifndef HFT_COMMON_HYBRIDIOSINK_HPP
+#define HFT_COMMON_HYBRIDIOSINK_HPP
+
+#include <spdlog/spdlog.h>
+
+#include "boost_types.hpp"
+#include "comparators.hpp"
+#include "config/config.hpp"
+#include "network_types.hpp"
+#include "template_types.hpp"
+#include "utils/utils.hpp"
+
+namespace hft {
+
+/**
+ * @brief
+ */
+template <typename... EventTypes>
+class HybridIoSink {
+  static constexpr size_t TypeCount = sizeof...(EventTypes);
+
+public:
+  HybridIoSink()
+      : mCtxGuard{mCtx.get_executor()}, mEventQueues(createLFQueueTuple<EventTypes...>(LFQ_SIZE)) {}
+
+  ~HybridIoSink() {
+    for (auto &thread : mThreads) {
+      if (thread.joinable()) {
+        thread.join();
+      }
+    }
+  }
+
+  void start() {
+    mThreads.reserve(Config::cfg.coresIo.size());
+    for (size_t i = 0; i < Config::cfg.coresIo.size(); ++i) {
+      mThreads.emplace_back([this, i]() {
+        try {
+          spdlog::trace("Started Io thread on the core: {}", Config::cfg.coresIo[i]);
+          utils::pinThreadToCore(Config::cfg.coresIo[i]);
+          utils::setTheadRealTime();
+          mCtx.run();
+        } catch (const std::exception &e) {
+          spdlog::error(e.what());
+        }
+      });
+    }
+    mCtx.run();
+  }
+
+  template <typename EventType>
+  void setHandler(SpanHandler<EventType> &&handler) {
+    constexpr auto index = getTypeIndex<EventType, EventTypes...>();
+    std::get<index>(mHandlers) = std::move(handler);
+  }
+
+  template <typename EventType>
+  void post(Span<EventType> events) {
+    auto &queue = getQueue<EventType>();
+    for (auto &event : events) {
+      while (!queue.push(event)) {
+        std::this_thread::yield();
+      }
+    }
+    if (!mHandlerPending.load(std::memory_order_relaxed)) {
+      mHandlerPending.store(true, std::memory_order_relaxed);
+      mCtx.post([this]() { processEvents(); });
+    }
+  }
+
+  void stop() { mCtx.stop(); }
+  IoContext &ctx() { return mCtx; }
+
+private:
+  template <typename EventType>
+  SpanHandler<EventType> &getHandler() {
+    constexpr auto index = getTypeIndex<EventType, EventTypes...>();
+    return std::get<index>(mHandlers);
+  }
+
+  void processEvents() {
+    mHandlerPending.store(false, std::memory_order_relaxed);
+    (processQueue<EventTypes>(), ...);
+  }
+
+  template <typename EventType>
+  void processQueue() {
+    auto &queue = getQueue<EventType>();
+    if (queue.empty()) {
+      return;
+    }
+    std::vector<EventType> events;
+    events.reserve(LFQ_POP_LIMIT);
+
+    EventType event;
+    while (events.size() < LFQ_POP_LIMIT && queue.pop(event)) {
+      events.emplace_back(std::move(event));
+    }
+    std::get<SpanHandler<EventType>>(mHandlers)(Span<EventType>(events));
+  }
+
+  template <typename EventType>
+  LFQueue<EventType> &getQueue() {
+    return *std::get<UPtrLFQueue<EventType>>(mEventQueues);
+  }
+
+private:
+  IoContext mCtx;
+  ContextGuard mCtxGuard;
+
+  std::tuple<UPtrLFQueue<EventTypes>...> mEventQueues;
+  std::tuple<SpanHandler<EventTypes>...> mHandlers;
+  std::atomic_bool mHandlerPending{false};
+
+  std::vector<std::thread> mThreads;
+};
+
+} // namespace hft
+
+#endif // HFT_COMMON_HYBRIDIOSINK_HPP

--- a/common/src/sink/io_sink.hpp
+++ b/common/src/sink/io_sink.hpp
@@ -16,9 +16,8 @@ namespace hft {
 
 /**
  * @brief Sink for Io operations. Events are being posted not on the IoContext
- * directly to minimize overhead, but rather io dependend objects register for events
- * and process them asynchronously. Runs Io context on a number of threads
- * along with the main thread joining
+ * directly to minimize overhead, but rather dispatchers register for events
+ * to process. Runs Io context on a number of threads
  */
 template <typename... EventTypes>
 class IoSink {
@@ -50,16 +49,14 @@ public:
   }
 
   template <typename EventType>
-    requires(std::disjunction_v<std::is_same<EventType, EventTypes>...>)
   void setHandler(CRefHandler<EventType> &&handler) {
-    constexpr auto index = utils::getTypeIndex<EventType, EventTypes...>();
+    constexpr auto index = getTypeIndex<EventType, EventTypes...>();
     std::get<index>(mHandlers) = std::move(handler);
   }
 
   template <typename EventType>
-    requires(std::disjunction_v<std::is_same<EventType, EventTypes>...>)
   void post(const EventType &event) {
-    constexpr auto index = utils::getTypeIndex<EventType, EventTypes...>();
+    constexpr auto index = getTypeIndex<EventType, EventTypes...>();
     std::get<index>(mHandlers)(event);
   }
 
@@ -69,7 +66,7 @@ public:
 private:
   template <typename EventType>
   CRefHandler<EventType> &getHandler() {
-    constexpr auto index = utils::getTypeIndex<EventType, EventTypes...>();
+    constexpr auto index = getTypeIndex<EventType, EventTypes...>();
     return std::get<index>(mHandlers);
   }
 

--- a/common/src/sink/partition_event_sink.hpp
+++ b/common/src/sink/partition_event_sink.hpp
@@ -31,18 +31,18 @@ namespace hft {
  * meanwhile working on another queues, once OrderBook is free, new thread takes over
  */
 template <typename LoadBalancer, typename... EventTypes>
-class BalancingEventSink {
+class PartitionEventSink {
 public:
   using Balancer = LoadBalancer;
 
-  BalancingEventSink() {
+  PartitionEventSink() {
     const auto threads = Config().cfg.coresApp.size();
     mEventQueues.reserve(threads);
     std::generate_n(std::back_inserter(mEventQueues), threads,
                     [this]() { return createLFQueueTuple<EventTypes...>(LFQ_SIZE); });
   }
 
-  ~BalancingEventSink() { stop(); }
+  ~PartitionEventSink() { stop(); }
 
   void start() {
     if (Config::cfg.coresApp.empty()) {
@@ -150,7 +150,7 @@ private:
 };
 
 template <typename LoadBalancer, typename... EventTypes>
-thread_local ThreadId BalancingEventSink<LoadBalancer, EventTypes...>::mThreadId = 0;
+thread_local ThreadId PartitionEventSink<LoadBalancer, EventTypes...>::mThreadId = 0;
 
 } // namespace hft
 

--- a/common/src/sink/partition_event_sink.hpp
+++ b/common/src/sink/partition_event_sink.hpp
@@ -12,6 +12,7 @@
 #include <unordered_map>
 
 #include "boost_types.hpp"
+#include "constants.hpp"
 #include "event_fd.hpp"
 #include "market_types.hpp"
 #include "network_types.hpp"
@@ -111,9 +112,7 @@ private:
     mEFd.wait();
     while (!mStop.load()) {
       (processQueue<EventTypes>(mThreadId), ...);
-      if (isTupleEmpty(mEventQueues[mThreadId])) {
-        mEFd.wait();
-      }
+      mEFd.wait([this]() { return !isTupleEmpty(mEventQueues[mThreadId]); });
     }
   }
 

--- a/common/src/sink/pool_event_sink.hpp
+++ b/common/src/sink/pool_event_sink.hpp
@@ -80,9 +80,7 @@ private:
     mEFd.wait();
     while (!mStop.load()) {
       (processQueue<EventTypes>(), ...);
-      if (isTupleEmpty(mEventQueues)) {
-        mEFd.wait();
-      }
+      mEFd.wait([this]() { return !isTupleEmpty(mEventQueues); });
     }
   }
 

--- a/common/src/types/boost_types.hpp
+++ b/common/src/types/boost_types.hpp
@@ -7,8 +7,6 @@
 #define HFT_COMMON_BOOST_TYPES_HPP
 
 #include <boost/asio.hpp>
-#include <boost/fiber/all.hpp>
-#include <boost/lockfree/queue.hpp>
 
 namespace hft {
 
@@ -19,19 +17,11 @@ using ContextGuard = boost::asio::executor_work_guard<IoContext::executor_type>;
 using BoostError = boost::system::error_code;
 using BoostErrorRef = const BoostError &;
 
-using Fiber = boost::fibers::fiber;
-
 using SteadyTimer = boost::asio::steady_timer;
 using Seconds = boost::asio::chrono::seconds;
 using MilliSeconds = boost::asio::chrono::milliseconds;
 using Microseconds = boost::asio::chrono::microseconds;
 using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
-
-template <typename EventType>
-using LFQueue = boost::lockfree::queue<EventType>;
-
-template <typename EventType>
-using UPtrLFQueue = std::unique_ptr<LFQueue<EventType>>;
 
 } // namespace hft
 

--- a/common/src/types/comparators.hpp
+++ b/common/src/types/comparators.hpp
@@ -1,0 +1,28 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-02-13
+ */
+
+#ifndef HFT_COMMON_MARKET_COMPARATORS_HPP
+#define HFT_COMMON_MARKET_COMPARATORS_HPP
+
+#include <algorithm>
+
+#include "market_types.hpp"
+#include "types.hpp"
+
+namespace hft {
+
+template <typename Type>
+struct TickerCmp {
+  bool operator()(const Type &left, const Type &right) { return left.ticker < right.ticker; }
+};
+
+template <typename Type>
+struct TraderIdCmp {
+  bool operator()(const Type &left, const Type &right) { return left.traderId < right.traderId; }
+};
+
+} // namespace hft
+
+#endif // HFT_COMMON_MARKET_COMPARATORS_HPP

--- a/common/src/types/constants.hpp
+++ b/common/src/types/constants.hpp
@@ -1,0 +1,33 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-02-13
+ */
+
+#ifndef HFT_COMMON_CONSTANTS_HPP
+#define HFT_COMMON_CONSTANTS_HPP
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <span>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+namespace hft {
+
+constexpr size_t BUFFER_SIZE = 1024 * 8;
+constexpr size_t LFQ_SIZE = 1024;
+constexpr size_t LFQ_POP_LIMIT = 10;
+constexpr size_t BUSY_WAIT_CYCLES = 1000000;
+
+#ifndef CACHE_LINE_SIZE
+#define CACHE_LINE_SIZE 64
+#endif
+
+} // namespace hft
+
+#endif // HFT_COMMON_TYPES_HPP

--- a/common/src/types/market_types.hpp
+++ b/common/src/types/market_types.hpp
@@ -61,7 +61,12 @@ struct TickerPrice {
   Price price;
 };
 
-constexpr size_t MAX_MESSAGE_SIZE = 256;
+template <typename Type>
+struct TickerCmp {
+  bool operator()(const Type &left, const Type &right) { return left.ticker < right.ticker; }
+};
+
+constexpr size_t MAX_MESSAGE_SIZE = 256; // TODO() fix this shit
 // std::max({sizeof(Order), sizeof(OrderStatus), sizeof(TickerPrice)}) + sizeof(uint16_t);
 
 } // namespace hft

--- a/common/src/types/market_types.hpp
+++ b/common/src/types/market_types.hpp
@@ -61,12 +61,7 @@ struct TickerPrice {
   Price price;
 };
 
-template <typename Type>
-struct TickerCmp {
-  bool operator()(const Type &left, const Type &right) { return left.ticker < right.ticker; }
-};
-
-constexpr size_t MAX_MESSAGE_SIZE = 256; // TODO() fix this shit
+constexpr size_t MAX_MESSAGE_SIZE = 90; // TODO() get more precise numbers
 // std::max({sizeof(Order), sizeof(OrderStatus), sizeof(TickerPrice)}) + sizeof(uint16_t);
 
 } // namespace hft

--- a/common/src/types/template_types.hpp
+++ b/common/src/types/template_types.hpp
@@ -19,20 +19,39 @@
 namespace hft {
 
 /**
- * Span
+ * Generic helpers
+ */
+template <typename EventType, typename First, typename... Rest>
+constexpr size_t indexOf() {
+  if constexpr (std::is_same_v<EventType, First>) {
+    return 0;
+  } else if constexpr (sizeof...(Rest) > 0) {
+    return 1 + indexOf<EventType, Rest...>();
+  } else {
+    static_assert(sizeof...(Rest) > 0, "EventType not found in EventTypes pack.");
+    return -1;
+  }
+}
+template <typename EventType, typename... Types>
+constexpr size_t getTypeIndex() {
+  return indexOf<EventType, Types...>();
+}
+
+/**
+ * span
  */
 template <typename Type>
 using Span = std::span<Type>;
 template <typename Type, typename Cmp>
-Span<Type> frontSubspan(Span<Type> input, Cmp cmp = Cmp{}) {
+std::pair<Span<Type>, Span<Type>> frontSubspan(Span<Type> input, Cmp cmp = Cmp{}) {
   if (input.size() < 2) {
-    return input;
+    return std::make_pair(input, Span<Type>());
   }
   size_t end = 0;
   while (end < input.size() && cmp(input.front(), input[end])) {
     ++end;
   }
-  return input.subspan(0, end);
+  return std::make_pair(input.subspan(0, end), input.subspan(end, input.size()));
 }
 
 /**

--- a/common/src/types/template_types.hpp
+++ b/common/src/types/template_types.hpp
@@ -1,0 +1,86 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-02-13
+ */
+
+#ifndef HFT_COMMON_TEMPLATETYPES_HPP
+#define HFT_COMMON_TEMPLATETYPES_HPP
+
+#include <algorithm>
+#include <boost/lockfree/queue.hpp>
+#include <functional>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "types.hpp"
+
+namespace hft {
+
+/**
+ * Span
+ */
+template <typename Type>
+using Span = std::span<Type>;
+template <typename Type, typename Cmp>
+Span<Type> frontSubspan(Span<Type> input, Cmp cmp = Cmp{}) {
+  if (input.size() < 2) {
+    return input;
+  }
+  size_t end = 0;
+  while (end < input.size() && cmp(input.front(), input[end])) {
+    ++end;
+  }
+  return input.subspan(0, end);
+}
+
+/**
+ * handler types
+ */
+using Callback = std::function<void()>;
+template <typename ArgType>
+using CRefHandler = std::function<void(const ArgType &)>;
+template <typename ArgType>
+using SpanHandler = std::function<void(Span<ArgType>)>;
+
+/**
+ * lock-free types
+ */
+template <typename EventType>
+using LFQueue = boost::lockfree::queue<EventType>;
+template <typename EventType>
+using UPtrLFQueue = std::unique_ptr<LFQueue<EventType>>;
+
+template <typename EventType>
+static UPtrLFQueue<EventType> createLFQueue(std::size_t size) {
+  return std::make_unique<LFQueue<EventType>>(size);
+}
+template <typename... TupleTypes>
+static std::tuple<UPtrLFQueue<TupleTypes>...> createLFQueueTuple(std::size_t size) {
+  return std::make_tuple(createLFQueue<TupleTypes>(size)...);
+}
+template <typename Type, typename... Types>
+static constexpr bool contains() {
+  return (std::is_same<Type, Types>::value || ...);
+}
+template <typename... Type>
+bool isTupleEmpty(const std::tuple<UPtrLFQueue<Type>...> &tupl) {
+  return std::apply([](const auto &...lfqs) { return (... && lfqs->empty()); }, tupl);
+}
+
+/**
+ * Padding helper
+ */
+template <typename... ValueTypes>
+struct Padding {
+  static constexpr size_t DataSize = (sizeof(ValueTypes) + ... + 0);
+  static constexpr size_t PaddingSize =
+      (CACHE_LINE_SIZE > DataSize) ? (CACHE_LINE_SIZE - DataSize) : 0;
+
+  std::array<char, PaddingSize> padding{};
+};
+
+} // namespace hft
+
+#endif // HFT_COMMON_TEMPLATETYPES_HPP

--- a/common/src/types/template_types.hpp
+++ b/common/src/types/template_types.hpp
@@ -58,6 +58,7 @@ std::pair<Span<Type>, Span<Type>> frontSubspan(Span<Type> input, Cmp cmp = Cmp{}
  * handler types
  */
 using Callback = std::function<void()>;
+using Predicate = std::function<bool()>;
 template <typename ArgType>
 using CRefHandler = std::function<void(const ArgType &)>;
 template <typename ArgType>

--- a/common/src/types/types.hpp
+++ b/common/src/types/types.hpp
@@ -12,42 +12,34 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <span>
 #include <stdint.h>
 #include <string>
 #include <vector>
 
 namespace hft {
 
-using String = std::string;
-using StringRef = const std::string &;
-using StringView = std::string_view;
-using ObjectId = uintptr_t;
-
 constexpr size_t BUFFER_SIZE = 1024 * 8;
-constexpr size_t EVENT_QUEUE_SIZE = 1024;
-
-using ByteBuffer = std::vector<uint8_t>;
-using SPtrByteBuffer = std::shared_ptr<ByteBuffer>;
-
-template <typename Arg>
-using CRefHandler = std::function<void(const Arg &)>;
-using Callback = std::function<void()>;
-
-using ThreadId = uint8_t;
-using TimestampRaw = uint32_t;
+constexpr size_t LFQ_SIZE = 1024;
+/**
+ * @brief Prevent infinite loop while consuming elements from lock free Q
+ * consume_all is not good enough as processing events in chunks is more efficient
+ * @todo try increasing and test
+ */
+constexpr size_t LFQ_POP_LIMIT = 10;
 
 #ifndef CACHE_LINE_SIZE
 #define CACHE_LINE_SIZE 64
 #endif
 
-template <typename... ValueTypes>
-struct Padding {
-  static constexpr size_t DataSize = (sizeof(ValueTypes) + ... + 0);
-  static constexpr size_t PaddingSize =
-      (CACHE_LINE_SIZE > DataSize) ? (CACHE_LINE_SIZE - DataSize) : 0;
-
-  std::array<char, PaddingSize> padding{};
-};
+using String = std::string;
+using StringRef = const std::string &;
+using StringView = std::string_view;
+using ObjectId = uintptr_t;
+using ByteBuffer = std::vector<uint8_t>;
+using SPtrByteBuffer = std::shared_ptr<ByteBuffer>;
+using ThreadId = uint8_t;
+using TimestampRaw = uint32_t;
 
 } // namespace hft
 

--- a/common/src/types/types.hpp
+++ b/common/src/types/types.hpp
@@ -19,19 +19,6 @@
 
 namespace hft {
 
-constexpr size_t BUFFER_SIZE = 1024 * 8;
-constexpr size_t LFQ_SIZE = 1024;
-/**
- * @brief Prevent infinite loop while consuming elements from lock free Q
- * consume_all is not good enough as processing events in chunks is more efficient
- * @todo try increasing and test
- */
-constexpr size_t LFQ_POP_LIMIT = 10;
-
-#ifndef CACHE_LINE_SIZE
-#define CACHE_LINE_SIZE 64
-#endif
-
 using String = std::string;
 using StringRef = const std::string &;
 using StringView = std::string_view;

--- a/common/src/utils/string_utils.hpp
+++ b/common/src/utils/string_utils.hpp
@@ -11,8 +11,9 @@
 #include <sstream>
 #include <string>
 
-#include "types/market_types.hpp"
-#include "types/types.hpp"
+#include "market_types.hpp"
+#include "template_types.hpp"
+#include "types.hpp"
 
 namespace hft::utils {
 
@@ -96,6 +97,15 @@ std::string toString(const std::vector<Type> &vec) {
   }
   ss << "]";
   return ss.str();
+}
+
+template <typename Type>
+std::string toString(Span<Type> elements) {
+  std::string result;
+  for (auto &element : elements) {
+    result += toString(element) + " ";
+  }
+  return result;
 }
 
 String toLower(String str) {

--- a/common/src/utils/utils.hpp
+++ b/common/src/utils/utils.hpp
@@ -47,23 +47,6 @@ std::string getScaleNs(size_t);
 size_t getId();
 void printRawPuffer(const uint8_t *buffer, size_t size);
 
-template <typename EventType, typename First, typename... Rest>
-constexpr size_t indexOf() {
-  if constexpr (std::is_same_v<EventType, First>) {
-    return 0;
-  } else if constexpr (sizeof...(Rest) > 0) {
-    return 1 + indexOf<EventType, Rest...>();
-  } else {
-    static_assert(sizeof...(Rest) > 0, "EventType not found in EventTypes pack.");
-    return -1;
-  }
-}
-
-template <typename EventType, typename... Types>
-constexpr size_t getTypeIndex() {
-  return indexOf<EventType, Types...>();
-}
-
 } // namespace hft::utils
 
 #endif // HFT_COMMON_UTILITIES_HPP

--- a/server/src/aggregator/price_feed.hpp
+++ b/server/src/aggregator/price_feed.hpp
@@ -70,9 +70,18 @@ private:
     if (cursor.end()) {
       cursor.reset();
     }
-    auto tickerPrice = *cursor;
-    mPrices.setPrice({tickerPrice.ticker, utils::RNG::rng<uint32_t>(900)});
-    mSink.ioSink.post(*cursor);
+    std::vector<TickerPrice> priceUpdates;
+    priceUpdates.reserve(10);
+    for (int i = 0; i < 10; ++i) {
+      auto tickerPrice = *cursor++;
+      if (cursor.end()) {
+        cursor.reset();
+      }
+      tickerPrice.price = utils::RNG::rng<uint32_t>(900);
+      mPrices.setPrice(tickerPrice);
+    }
+
+    mSink.ioSink.post(Span<TickerPrice>(priceUpdates));
     cursor++;
   }
 

--- a/server/src/network/broadcast_server.hpp
+++ b/server/src/network/broadcast_server.hpp
@@ -26,9 +26,9 @@ public:
   BroadcastServer(ServerSink &sink)
       : mSink{sink}, mSocket{mSink, createSocket(sink.ctx()),
                              UdpEndpoint{Ip::address_v4::broadcast(), Config::cfg.portUdp}} {
-    mSink.ioSink.setHandler<TickerPrice>([this](const TickerPrice &price) {
-      spdlog::debug(utils::toString(price));
-      mSocket.asyncWrite(price);
+    mSink.ioSink.setHandler<TickerPrice>([this](Span<TickerPrice> prices) {
+      spdlog::debug(utils::toString(prices));
+      mSocket.asyncWrite(prices);
     });
   }
 

--- a/server/src/server_types.hpp
+++ b/server/src/server_types.hpp
@@ -10,9 +10,10 @@
 #include "market_types.hpp"
 #include "network/async_socket.hpp"
 #include "serialization/flat_buffers/fb_serializer.hpp"
-#include "sink/balancing_event_sink.hpp"
 #include "sink/command_sink.hpp"
+#include "sink/hybrid_io_sink.hpp"
 #include "sink/io_sink.hpp"
+#include "sink/partition_event_sink.hpp"
 #include "sink/pool_event_sink.hpp"
 
 namespace hft::server {
@@ -22,8 +23,8 @@ class OrderTrafficStats;
 class MapOrderBook;
 class FlatOrderBook;
 
-using EventSink = BalancingEventSink<Aggregator, Order>;
-using ServerIoSink = IoSink<OrderStatus, TickerPrice>;
+using EventSink = PartitionEventSink<Aggregator, Order>;
+using ServerIoSink = HybridIoSink<OrderStatus, TickerPrice>;
 using ServerControlSink = ControlSink<ServerCommand, OrderTrafficStats>;
 using Serializer = hft::serialization::FlatBuffersSerializer;
 using OrderBook = MapOrderBook;

--- a/trader/src/hft_trader.hpp
+++ b/trader/src/hft_trader.hpp
@@ -31,6 +31,7 @@ public:
     mSink.controlSink.start();
     mServer.start();
     mSink.ioSink.start();
+    return;
   }
 
   void stop() {

--- a/trader/src/main.cpp
+++ b/trader/src/main.cpp
@@ -5,6 +5,7 @@
 
 #include "config/config.hpp"
 #include "config/config_reader.hpp"
+#include "event_fd.hpp"
 #include "hft_trader.hpp"
 #include "logger_manager.hpp"
 #include "utils/string_utils.hpp"

--- a/trader/src/network/network_server.hpp
+++ b/trader/src/network/network_server.hpp
@@ -27,7 +27,7 @@ public:
                       TcpEndpoint{Ip::make_address(Config::cfg.url), Config::cfg.portTcpOut}},
         mPriceSocket{sink, createUdpSocket(sink.ctx()),
                      UdpEndpoint(Udp::v4(), Config::cfg.portUdp)} {
-    mSink.ioSink.setHandler<Order>([this](const Order &order) { mOrderSocket.asyncWrite(order); });
+    mSink.ioSink.setHandler<Order>([this](Span<Order> orders) { mOrderSocket.asyncWrite(orders); });
   }
 
   void start() {

--- a/trader/src/strategy/buy_some_sell_some_strategy.hpp
+++ b/trader/src/strategy/buy_some_sell_some_strategy.hpp
@@ -78,7 +78,7 @@ private:
     order.action = utils::RNG::rng(1) == 0 ? OrderAction::Buy : OrderAction::Sell;
     order.quantity = utils::RNG::rng(1000);
     spdlog::debug("Placing order {}", utils::toString(order));
-    mSink.ioSink.post(order);
+    mSink.ioSink.post(Span<Order>{&order, 1});
   }
 
   void processCommand(TraderCommand cmd) {

--- a/trader/src/strategy/buy_some_sell_some_strategy.hpp
+++ b/trader/src/strategy/buy_some_sell_some_strategy.hpp
@@ -46,7 +46,7 @@ private:
     for (auto &price : prices) {
       pricesStr += utils::toString(price) + " ";
     }
-    spdlog::info(pricesStr);
+    spdlog::info("PriceUpdate: {}", pricesStr);
   }
 
   void orderUpdates(Span<OrderStatus> statuses) {

--- a/trader/src/trader_types.hpp
+++ b/trader/src/trader_types.hpp
@@ -10,9 +10,10 @@
 #include "market_types.hpp"
 #include "network/async_socket.hpp"
 #include "serialization/flat_buffers/fb_serializer.hpp"
-#include "sink/balancing_event_sink.hpp"
 #include "sink/command_sink.hpp"
+#include "sink/hybrid_io_sink.hpp"
 #include "sink/io_sink.hpp"
+#include "sink/partition_event_sink.hpp"
 #include "sink/pool_event_sink.hpp"
 
 namespace hft::trader {
@@ -20,7 +21,7 @@ namespace hft::trader {
 struct TradingStats;
 
 using EventSink = PoolEventSink<OrderStatus, TickerPrice>;
-using TraderIoSink = IoSink<Order>;
+using TraderIoSink = HybridIoSink<Order>;
 using TraderControlSink = ControlSink<TraderCommand, TradingStats>;
 
 using Serializer = hft::serialization::FlatBuffersSerializer;


### PR DESCRIPTION
- Reworked IoSink making it buffer outgoing messages
- Reworked all event flow to work with std::span instead of single events
- Added EventFd class to improve busy waiting in sinks

Previously whenever match happens, response would be sent right away, and IoCtx loop gets congested with small messages. I added additional layer of lock free queues to IoSink. New event gets pushed into a queue and (if not yet) handler gets posted into the IoCtx that would process all the events at once. So buffering is only dependent on IoCtx loop load.

This shows some crazy improvements in RTT distribution, it completely eliminated all 1ms-50ms spikes

Before:
Server: [15:50:41.408] [I] [open|total]: 341401|535799 RPS:9220
Client:  [15:50:17.915] [I] RTT [1us|100us|1ms]  94.66% avg:24us  0.13% avg:433us  5.21% avg:25ms

After:
Server: [14:59:10.416] [I] [open|total]: 345135|541083 RPS:9026
Client:  [14:59:09.220] [I] RTT [1us|100us|1ms]  99.90% avg:26us  0.10% avg:132us  0.00% avg:0ms