### PR TITLE
Added simpler version of server based on io_context and one thread pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,20 @@ target_compile_definitions(hft_server PRIVATE)
 target_link_libraries(hft_server PRIVATE hft_common ${Boost_LIBRARIES} spdlog::spdlog ${LIBPQXX_LIBRARIES} atomic)
 target_include_directories(hft_server PRIVATE  common/src server/src server/src/types)
 
+# Server v2 Target
+file(GLOB_RECURSE SERVER_V2_SOURCES "server_v2/src/*.cpp" "server_v2/src/**/*.cpp" "server_v2/src/*.hpp" "server_v2/src/**/*.hpp")
+add_executable(hft_server_v2 ${SERVER_V2_SOURCES})
+target_compile_definitions(hft_server_v2 PRIVATE)
+target_link_libraries(hft_server_v2 PRIVATE hft_common ${Boost_LIBRARIES} spdlog::spdlog ${LIBPQXX_LIBRARIES} atomic)
+target_include_directories(hft_server_v2 PRIVATE common/src server_v2/src)
+
 # Trader Target
 file(GLOB_RECURSE TRADER_SOURCES "trader/src/*.cpp" "trader/src/**/*.cpp" "trader/src/*.hpp" "trader/src/**/*.hpp")
 add_executable(hft_trader ${TRADER_SOURCES})
 target_compile_definitions(hft_trader PRIVATE)
 target_link_libraries(hft_trader PRIVATE hft_common ${Boost_LIBRARIES} spdlog::spdlog ${LIBPQXX_LIBRARIES} atomic)
 target_include_directories(hft_trader PRIVATE common/src trader/src trader/src/types)
+
 
 # mimalloc
 if(USE_MIMALLOC)
@@ -75,6 +83,7 @@ if(USE_MIMALLOC)
 endif()
 
 add_dependencies(hft_server code_generator)
+add_dependencies(hft_server_v2 code_generator)
 add_dependencies(hft_trader code_generator)
 
 add_custom_command(

--- a/common/src/console/control_center_base.hpp
+++ b/common/src/console/control_center_base.hpp
@@ -51,7 +51,7 @@ private:
   void processCommands() {
     auto cmdRes = mConsoleParser.getCommand();
     while (cmdRes.ok()) {
-      auto cmd = cmdRes.value();
+      auto cmd = cmdRes.value;
       switch (cmd) {
       case Command::LogLevelUp:
         Logger::switchLogLevel(true);

--- a/common/src/network/async_socket.hpp
+++ b/common/src/network/async_socket.hpp
@@ -159,7 +159,7 @@ private:
         mHead = mTail = 0;
         break;
       }
-      mReadMsgBuffer.emplace_back(result.value());
+      mReadMsgBuffer.emplace_back(result.value);
       if constexpr (!std::is_same_v<MessageTypeIn, TickerPrice>) {
         mReadMsgBuffer.back().traderId = getTraderId();
       }

--- a/common/src/pool/buffer_pool.hpp
+++ b/common/src/pool/buffer_pool.hpp
@@ -27,7 +27,7 @@ struct BufferPool {
     size_t retries = 0;
     while ((newHead > currHead) ? (currHead < currTail && currTail < newHead)
                                 : (currHead < currTail || currTail < newHead)) {
-      if (retries++ > 100) {
+      if (retries++ > 1000) {
         throw std::runtime_error("Failed to acquire memory buffer, no space in the pool");
       }
       // Wait for some async write operation to free up the space
@@ -55,7 +55,7 @@ struct BufferPool {
     size_t retries = 0;
     while (!tail.compare_exchange_weak(expectedTail, nextTail, std::memory_order_release,
                                        std::memory_order_acquire)) {
-      if (retries++ > 100) {
+      if (retries++ > 1000) {
         throw std::runtime_error("Failed to release memory buffer");
       }
       currentTail = expectedTail;

--- a/common/src/types/boost_types.hpp
+++ b/common/src/types/boost_types.hpp
@@ -12,7 +12,9 @@ namespace hft {
 
 namespace Ip = boost::asio::ip;
 using IoContext = boost::asio::io_context;
+using UPtrIoContext = std::unique_ptr<boost::asio::io_context>;
 using ContextGuard = boost::asio::executor_work_guard<IoContext::executor_type>;
+using UPtrContextGuard = std::unique_ptr<ContextGuard>;
 
 using BoostError = boost::system::error_code;
 using BoostErrorRef = const BoostError &;

--- a/common/src/types/result.hpp
+++ b/common/src/types/result.hpp
@@ -14,19 +14,15 @@
 namespace hft {
 
 template <typename ValueType>
-class Result {
-public:
-  Result() : mValue{ValueType{}, StatusCode::Empty} {}
-  Result(ValueType value) : mValue{std::move(value), StatusCode::Ok} {}
-  Result(StatusCode error) : mValue{ValueType{}, error} {}
+struct Result {
+  Result() : code{StatusCode::Empty} {}
+  Result(ValueType value) : value{std::move(value)}, code{StatusCode::Ok} {}
+  Result(StatusCode error) : code{error} {}
 
-  bool ok() const { return mValue.second == StatusCode::Ok; }
-  operator bool() const { return ok(); }
-  const ValueType &value() const { return mValue.first; }
-  StatusCode error() const { return mValue.second; }
+  bool ok() const { return code == StatusCode::Ok; }
 
-private:
-  std::pair<ValueType, StatusCode> mValue;
+  ValueType value;
+  StatusCode code;
 };
 
 } // namespace hft

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,10 @@ ulimit -c unlimited
 if [ "$1" == "s" ]; then
     rm -f server_log.*.txt
     sudo ./hft_server
-else [ "$1" == "t" ] || [ "$1" == "trader" ];
+elif [ "$1" == "t" ]; then
     rm -f trader_log.*.txt
     sudo ./hft_trader
+else [ "$1" == "s2" ];
+    rm -f server_log.*.txt
+    sudo ./hft_server_v2
 fi

--- a/server_v2/src/hft_server.hpp
+++ b/server_v2/src/hft_server.hpp
@@ -1,0 +1,201 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-02-13
+ */
+
+#ifndef HFT_SERVER_HFTSERVER_HPP
+#define HFT_SERVER_HFTSERVER_HPP
+
+#include <fcntl.h>
+#include <format>
+#include <iostream>
+#include <memory>
+#include <unordered_map>
+
+#include "boost_types.hpp"
+#include "comparators.hpp"
+#include "config/config.hpp"
+#include "db/postgres_adapter.hpp"
+#include "market_types.hpp"
+#include "network_types.hpp"
+#include "order_book.hpp"
+#include "server_tcp_socket.hpp"
+#include "template_types.hpp"
+#include "types.hpp"
+#include "utils/utils.hpp"
+
+namespace hft {
+
+class Server {
+  using Socket = ServerTcpSocket<Order>;
+  using UPtrSocket = std::unique_ptr<Socket>;
+  using UPtrOrderBook = std::unique_ptr<FlatOrderBook>;
+
+  struct Session {
+    UPtrSocket ingress;
+    UPtrSocket egress;
+  };
+
+public:
+  Server() : mIngressAcceptor{mCtx}, mEgressAcceptor{mCtx}, mTimer{mCtx} {
+    fcntl(STDIN_FILENO, F_SETFL, O_NONBLOCK);
+    std::cout << std::unitbuf;
+
+    initMarketData();
+    startWorkers();
+    startIngress();
+    startEgress();
+    scheduleTimer();
+  }
+  ~Server() {
+    for (auto &thread : mWorkerThreads) {
+      if (thread.joinable()) {
+        thread.join();
+      }
+    }
+  }
+
+  void start() { mCtx.run(); }
+  void stop() { mCtx.stop(); }
+
+private:
+  void startIngress() {
+    TcpEndpoint endpoint(Tcp::v4(), Config::cfg.portTcpIn);
+    mIngressAcceptor.open(endpoint.protocol());
+    mIngressAcceptor.bind(endpoint);
+    mIngressAcceptor.listen();
+    acceptIngress();
+  }
+
+  void acceptIngress() {
+    mIngressAcceptor.async_accept([this](BoostErrorRef ec, TcpSocket socket) {
+      socket.set_option(TcpSocket::protocol_type::no_delay(true));
+      if (ec) {
+        spdlog::error("Failed to accept connection {}", ec.message());
+        return;
+      }
+      auto traderId = utils::getTraderId(socket);
+      Logger::monitorLogger->info("{} connected", traderId);
+      mSessions[traderId].ingress = std::make_unique<Socket>(
+          std::move(socket), traderId,
+          [this, traderId](const Order &order) { dispatchOrder(traderId, order); });
+      mSessions[traderId].ingress->asyncRead();
+      acceptIngress();
+    });
+  }
+
+  void startEgress() {
+    TcpEndpoint endpoint(Tcp::v4(), Config::cfg.portTcpOut);
+    mEgressAcceptor.open(endpoint.protocol());
+    mEgressAcceptor.bind(endpoint);
+    mEgressAcceptor.listen();
+    acceptEgress();
+  }
+
+  void acceptEgress() {
+    mEgressAcceptor.async_accept([this](BoostErrorRef ec, TcpSocket socket) {
+      if (ec) {
+        spdlog::error("Failed to accept connection: {}", ec.message());
+        return;
+      }
+      socket.set_option(TcpSocket::protocol_type::no_delay(true));
+      auto id = utils::getTraderId(socket);
+      Logger::monitorLogger->info("{} connected", id);
+      mSessions[id].egress = std::make_unique<Socket>(std::move(socket), id, [](const Order &) {});
+      acceptEgress();
+    });
+  }
+
+  void startWorkers() {
+    mWorkerContexts.reserve(Config::cfg.coresApp.size());
+    mWorkerGuards.reserve(Config::cfg.coresApp.size());
+    for (int i = 0; i < Config::cfg.coresApp.size(); ++i) {
+      mWorkerContexts.emplace_back(std::make_unique<IoContext>());
+      mWorkerGuards.emplace_back(
+          std::make_unique<ContextGuard>(boost::asio::make_work_guard(*mWorkerContexts.back())));
+      mWorkerThreads.emplace_back([this, i]() {
+        try {
+          mWorkerContexts[i]->run();
+        } catch (const std::exception &e) {
+          Logger::monitorLogger->error("Exception in worker thread {}", e.what());
+        }
+      });
+    }
+  }
+
+  size_t getTicketHash(const Ticker &ticker) {
+    return std::hash<std::string_view>{}(std::string_view(ticker.data(), ticker.size()));
+  }
+
+  ThreadId getWorkerId(const Ticker &ticker) {
+    return getTicketHash(ticker) % Config::cfg.coresApp.size();
+  }
+
+  void dispatchOrder(TraderId traderId, const Order &order) {
+    mOrdersTotal.fetch_add(1, std::memory_order_relaxed);
+    ThreadId workerId = getWorkerId(order.ticker);
+    boost::asio::post(*mWorkerContexts[workerId], [this, order, traderId]() {
+      size_t tickerId = getTicketHash(order.ticker);
+      mOrderBooks[tickerId]->add(order);
+      auto matches = mOrderBooks[tickerId]->match();
+      mSessions[traderId].egress->asyncWrite(Span<OrderStatus>(matches));
+      mOrdersClosed.fetch_add(matches.size(), std::memory_order_relaxed);
+    });
+  }
+
+  void initMarketData() {
+    auto tickers = db::PostgresAdapter::readTickers();
+    for (auto &item : tickers) {
+      mOrderBooks[getTicketHash(item.ticker)] = std::make_unique<FlatOrderBook>();
+    }
+  }
+
+  void scheduleTimer() {
+    mTimer.expires_after(Seconds(1));
+    mTimer.async_wait([this](BoostErrorRef ec) {
+      if (ec) {
+        return;
+      }
+      checkInput();
+      Logger::monitorLogger->info("Orders [matched|total] {} {}",
+                                  mOrdersClosed.load(std::memory_order_relaxed),
+                                  mOrdersTotal.load(std::memory_order_relaxed));
+      scheduleTimer();
+    });
+  }
+
+  void checkInput() {
+    struct pollfd fds = {STDIN_FILENO, POLLIN, 0};
+    if (poll(&fds, 1, 0) == 1) {
+      std::string cmd;
+      std::getline(std::cin, cmd);
+      if (cmd == "q") {
+        mCtx.stop();
+        for (auto &ctx : mWorkerContexts) {
+          ctx->stop();
+        }
+      }
+    }
+  }
+
+private:
+  IoContext mCtx;
+
+  TcpAcceptor mIngressAcceptor;
+  TcpAcceptor mEgressAcceptor;
+  SteadyTimer mTimer;
+
+  std::vector<UPtrIoContext> mWorkerContexts;
+  std::vector<UPtrContextGuard> mWorkerGuards;
+  std::vector<std::thread> mWorkerThreads;
+
+  std::unordered_map<size_t, Session> mSessions;
+  std::unordered_map<size_t, UPtrOrderBook> mOrderBooks;
+
+  std::atomic_size_t mOrdersTotal;
+  std::atomic_size_t mOrdersClosed;
+};
+
+} // namespace hft
+
+#endif // HFT_SERVER_HFTSERVER_HPP

--- a/server_v2/src/main.cpp
+++ b/server_v2/src/main.cpp
@@ -1,0 +1,32 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-02-13
+ */
+
+#include "config/config.hpp"
+#include "config/config_reader.hpp"
+#include "hft_server.hpp"
+#include "logger.hpp"
+#include "utils/string_utils.hpp"
+
+int main() {
+  using namespace hft;
+  std::unique_ptr<Server> server;
+  try {
+    Logger::initialize(spdlog::level::trace, "server_log.txt");
+    ConfigReader::readConfig("server_config.ini");
+
+    Logger::monitorLogger->info("Server configuration:");
+    Config::cfg.logConfig();
+    Logger::monitorLogger->info("LogLevel:{}", utils::toString(spdlog::get_level()));
+
+    server = std::make_unique<Server>();
+    server->start();
+  } catch (const std::exception &e) {
+    Logger::monitorLogger->critical("Exception caught in main {}", e.what());
+    spdlog::critical("Exception caught in main {}", e.what());
+    spdlog::default_logger()->flush();
+    server->stop();
+  }
+  return 0;
+}

--- a/server_v2/src/order_book.hpp
+++ b/server_v2/src/order_book.hpp
@@ -1,0 +1,107 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-02-20
+ */
+
+#ifndef HFT_SERVER_FLATORDERBOOK_HPP
+#define HFT_SERVER_FLATORDERBOOK_HPP
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "market_types.hpp"
+#include "types.hpp"
+#include "utils/rng.hpp"
+#include "utils/string_utils.hpp"
+
+namespace hft {
+
+class FlatOrderBook {
+  static bool compareBids(const Order &left, const Order &right) {
+    return left.price < right.price;
+  }
+  static bool compareAsks(const Order &left, const Order &right) {
+    return left.price > right.price;
+  }
+
+public:
+  using UPtr = std::unique_ptr<FlatOrderBook>;
+
+  FlatOrderBook() {
+    mBids.reserve(500);
+    mAsks.reserve(500);
+  }
+  ~FlatOrderBook() = default;
+
+  void add(const Order &order) {
+    if (order.action == OrderAction::Buy) {
+      mBids.push_back(order);
+      std::push_heap(mBids.begin(), mBids.end(), compareBids);
+    } else {
+      mAsks.push_back(order);
+      std::push_heap(mAsks.begin(), mAsks.end(), compareAsks);
+    }
+    mLastAdded.insert(order.id); // Randomizator
+  }
+
+  std::vector<OrderStatus> match() {
+    std::vector<OrderStatus> matches;
+    matches.reserve(10);
+
+    while (!mBids.empty() && !mAsks.empty()) {
+      Order &bestBid = mBids.front();
+      Order &bestAsk = mAsks.front();
+      if (bestBid.price < bestAsk.price) {
+        break;
+      }
+      auto quantity = std::min(bestBid.quantity, bestAsk.quantity);
+      bestBid.quantity -= quantity;
+      bestAsk.quantity -= quantity;
+
+      if (mLastAdded.contains(bestBid.id)) {
+        matches.emplace_back(handleMatch(bestBid, quantity, bestAsk.price));
+      }
+      if (mLastAdded.contains(bestAsk.id)) {
+        matches.emplace_back(handleMatch(bestAsk, quantity, bestAsk.price));
+      }
+
+      if (bestBid.quantity == 0) {
+        std::pop_heap(mBids.begin(), mBids.end(), compareBids);
+        mBids.pop_back();
+      }
+      if (bestAsk.quantity == 0) {
+        std::pop_heap(mAsks.begin(), mAsks.end(), compareAsks);
+        mAsks.pop_back();
+      }
+    }
+    mLastAdded.clear();
+    return matches;
+  }
+
+private:
+  OrderStatus handleMatch(const Order &order, Quantity quantity, Price price) {
+    OrderStatus status;
+    status.id = order.id;
+    status.state = (order.quantity == 0) ? OrderState::Full : OrderState::Partial;
+    status.quantity = quantity;
+    status.fillPrice = price;
+    status.action = order.action;
+    status.traderId = order.traderId;
+    status.ticker = order.ticker;
+    spdlog::trace(utils::toString(status));
+    return status;
+  }
+
+private:
+  std::vector<Order> mBids;
+  std::vector<Order> mAsks;
+  std::set<OrderId> mLastAdded;
+};
+
+} // namespace hft
+
+#endif // HFT_SERVER_MAPORDERBOOK_HPP

--- a/server_v2/src/server_tcp_socket.hpp
+++ b/server_v2/src/server_tcp_socket.hpp
@@ -1,0 +1,138 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-02-13
+ */
+
+#ifndef HFT_COMMON_ASYNCSOCKET_HPP
+#define HFT_COMMON_ASYNCSOCKET_HPP
+
+#include <boost/endian/arithmetic.hpp>
+#include <boost/endian/conversion.hpp>
+#include <memory>
+#include <spdlog/spdlog.h>
+#include <vector>
+
+#include "boost_types.hpp"
+#include "constants.hpp"
+#include "network_types.hpp"
+#include "pool/buffer_pool.hpp"
+#include "serialization/flat_buffers/fb_serializer.hpp"
+#include "types.hpp"
+#include "utils/string_utils.hpp"
+
+namespace hft {
+
+template <typename MessageTypeIn>
+class ServerTcpSocket {
+public:
+  using Type = ServerTcpSocket<MessageTypeIn>;
+  using MessageIn = MessageTypeIn;
+  using UPtr = std::unique_ptr<Type>;
+  using Serializer = serialization::FlatBuffersSerializer;
+
+  ServerTcpSocket(TcpSocket &&socket, TraderId id, CRefHandler<MessageIn> handler)
+      : mSocket{std::move(socket)}, mId{id}, mHandler{std::move(handler)}, mReadBuffer(BUFFER_SIZE),
+        mWritePool{WRITE_BUFFER_POOL_SIZE} {}
+
+  void asyncRead() {
+    size_t writable = mReadBuffer.size() - mTail;
+    uint8_t *writePtr = mReadBuffer.data() + mTail;
+
+    mSocket.async_read_some(
+        boost::asio::buffer(writePtr, writable),
+        [this](BoostErrorRef code, size_t bytesRead) { readHandler(code, bytesRead); });
+  }
+
+  template <typename MessageTypeOut>
+  void asyncWrite(Span<MessageTypeOut> msgVec) {
+    size_t allocSize = msgVec.size() * MAX_SERIALIZED_MESSAGE_SIZE;
+    auto dataPtr = mWritePool.acquire(allocSize); // std::make_shared<ByteBuffer>(allocSize);
+
+    size_t totalSize{0};
+    uint8_t *cursor = dataPtr;
+    for (auto &msg : msgVec) {
+      auto msgSize = serializeMessage(msg, cursor);
+      cursor += msgSize;
+      totalSize += msgSize;
+    }
+
+    boost::asio::async_write(mSocket, boost::asio::buffer(dataPtr, totalSize),
+                             [this, allocSize](BoostErrorRef ec, size_t size) {
+                               BufferGuard guard(mWritePool, allocSize);
+                               if (ec) {
+                                 spdlog::error("Write failed: {}", ec.message());
+                               }
+                             });
+  }
+
+private:
+  template <typename Type>
+  boost::endian::little_int16_at serializeMessage(Type &msg, uint8_t *cursor) {
+    auto buffer = Serializer::serialize(msg);
+    boost::endian::little_int16_at bodySize = static_cast<MessageSize>(buffer.size());
+
+    std::memcpy(cursor, &bodySize, sizeof(bodySize));
+    std::memcpy(cursor + sizeof(bodySize), buffer.data(), buffer.size());
+
+    return bodySize + sizeof(bodySize);
+  }
+
+  void readHandler(BoostErrorRef ec, size_t bytesRead) {
+    if (ec) {
+      mHead = mTail = 0;
+      if (ec != boost::asio::error::eof) {
+        spdlog::error(ec.message());
+      }
+      return;
+    }
+    mTail += bytesRead;
+    while (mHead + sizeof(MessageSize) < mTail) {
+      uint8_t *cursor = mReadBuffer.data() + mHead;
+      boost::endian::little_int16_at littleBodySize = 0;
+      std::memcpy(&littleBodySize, cursor, sizeof(littleBodySize));
+      MessageSize bodySize = littleBodySize.value();
+      if (mHead + sizeof(MessageSize) + bodySize > mReadBuffer.size()) {
+        rotateBuffer();
+        break;
+      }
+      if (mHead + sizeof(MessageSize) + bodySize > mTail) {
+        // continue reading;
+        break;
+      }
+      cursor += sizeof(MessageSize);
+      auto result = Serializer::template deserialize<MessageIn>(cursor, bodySize);
+      if (!result.ok()) {
+        mHead = mTail = 0;
+        break;
+      }
+      result.value.traderId = mId;
+      mHandler(result.value);
+      mHead += bodySize + sizeof(MessageSize);
+    }
+    if (mReadBuffer.size() - mTail < 256) {
+      rotateBuffer();
+    }
+    asyncRead();
+  }
+
+  void rotateBuffer() {
+    std::memmove(mReadBuffer.data(), mReadBuffer.data() + mHead, mTail - mHead);
+    mTail = mTail - mHead;
+    mHead = 0;
+  }
+
+private:
+  TcpSocket mSocket;
+  CRefHandler<MessageIn> mHandler;
+
+  size_t mHead{0};
+  size_t mTail{0};
+  ByteBuffer mReadBuffer;
+  BufferPool mWritePool;
+
+  TraderId mId{};
+};
+
+} // namespace hft
+
+#endif // HFT_COMMON_ASYNCSOCKET_HPP


### PR DESCRIPTION
Simpler version of a server without lock free queues and dedicated sink for processing orders, instead fully based on io contexts and one thread pool for everything. Every worker thread gets separate io context and tickers get processed separately. Performance turns out to be almost the same comparing to the previous version.