### PR TITLE
boost object pool

### DIFF
--- a/benchmarks/build.sh
+++ b/benchmarks/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+clear
+
+set -e
+
+BUILD_DIR="build"
+
+if [ "$1" == "c" ]; then
+    rm -rf CMakeCache.txt CMakeFiles
+    rm -rf build/
+fi
+
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)

--- a/benchmarks/src/benchmark.cpp
+++ b/benchmarks/src/benchmark.cpp
@@ -1,0 +1,13 @@
+#include <benchmark/benchmark.h>
+
+void someFunction() {}
+
+static void BM_ServerFunction(benchmark::State &state) {
+  for (auto _ : state) {
+    someFunction();
+  }
+}
+
+BENCHMARK(BM_ServerFunction);
+
+BENCHMARK_MAIN();

--- a/common/src/pool/object_pool.hpp
+++ b/common/src/pool/object_pool.hpp
@@ -1,0 +1,68 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-03-01
+ */
+
+#ifndef HFT_COMMON_OBJECTPOOL_HPP
+#define HFT_COMMON_OBJECTPOOL_HPP
+
+#include <boost/pool/singleton_pool.hpp>
+#include <memory>
+
+namespace hft {
+
+template <typename ObjectType>
+class PoolPtr {
+  template <typename T>
+  struct PoolTag {};
+
+public:
+  using PtrType = PoolPtr<ObjectType>;
+  using PoolType = boost::singleton_pool<PoolTag<ObjectType>, sizeof(ObjectType)>;
+
+  PoolPtr() = default;
+  explicit PoolPtr(ObjectType *ptr) : mPtr{ptr} {}
+  PoolPtr(PoolPtr &&other) noexcept : mPtr{std::exchange(other.mPtr, nullptr)} {}
+  PoolPtr &operator=(PoolPtr &&other) noexcept {
+    if (this != &other) {
+      reset();
+      mPtr = std::exchange(other.mPtr, nullptr);
+    }
+    return *this;
+  }
+  PoolPtr(const PoolPtr &) = delete;
+  PoolPtr &operator=(const PoolPtr &) = delete;
+
+  ~PoolPtr() { reset(); }
+
+  ObjectType *operator->() { return mPtr; }
+  const ObjectType *operator->() const { return mPtr; }
+  ObjectType &operator*() { return *mPtr; }
+  const ObjectType &operator*() const { return *mPtr; }
+  explicit operator bool() const { return mPtr != nullptr; }
+
+  void reset() {
+    if (mPtr) {
+      mPtr->~ObjectType();
+      PoolType::free(mPtr);
+      mPtr = nullptr;
+    }
+  }
+
+  static PtrType create() {
+    void *mem = PoolType::malloc();
+    if (!mem) {
+      throw std::bad_alloc();
+    }
+    return PtrType(new (mem) ObjectType());
+  }
+
+  friend void swap(PoolPtr &left, PoolPtr &right) noexcept { std::swap(left.mPtr, right.mPtr); }
+
+private:
+  ObjectType *mPtr{nullptr};
+};
+
+} // namespace hft
+
+#endif // HFT_COMMON_OBJECTPOOL_HPP

--- a/common/src/serialization/flat_buffers/fb_serializer.hpp
+++ b/common/src/serialization/flat_buffers/fb_serializer.hpp
@@ -10,6 +10,7 @@
 
 #include "converter.hpp"
 #include "gen/marketdata_generated.h"
+#include "pool/object_pool.hpp"
 #include "types/market_types.hpp"
 #include "types/result.hpp"
 #include "types/types.hpp"
@@ -21,74 +22,81 @@ public:
   using DetachedBuffer = flatbuffers::DetachedBuffer;
 
   template <typename MessageType>
-  static std::enable_if_t<std::is_same<MessageType, Order>::value, Result<Order>>
+  static std::enable_if_t<std::is_same<MessageType, PoolPtr<Order>>::value, PoolPtr<Order>>
   deserialize(const uint8_t *buffer, size_t size) {
     flatbuffers::Verifier verifier(buffer, size);
     if (!verifier.VerifyBuffer<gen::fbs::Order>()) {
       spdlog::error("Order verification failed");
-      return StatusCode::Error;
+      return PoolPtr<Order>();
     }
     auto msg = flatbuffers::GetRoot<gen::fbs::Order>(buffer);
-    return Order{0,
-                 msg->id(),
-                 fbStringToTicker(msg->ticker()),
-                 msg->quantity(),
-                 msg->price(),
-                 convert(msg->action())};
+    auto orderPtr = PoolPtr<Order>::create();
+    orderPtr->id = msg->id();
+    orderPtr->ticker = fbStringToTicker(msg->ticker());
+    orderPtr->quantity = msg->quantity();
+    orderPtr->price = msg->price();
+    orderPtr->action = convert(msg->action());
+    return orderPtr;
   }
 
   template <typename MessageType>
-  static std::enable_if_t<std::is_same<MessageType, OrderStatus>::value, Result<OrderStatus>>
+  static std::enable_if_t<std::is_same<MessageType, PoolPtr<OrderStatus>>::value,
+                          PoolPtr<OrderStatus>>
   deserialize(const uint8_t *buffer, size_t size) {
     flatbuffers::Verifier verifier(buffer, size);
     if (!verifier.VerifyBuffer<gen::fbs::OrderStatus>()) {
       spdlog::error("OrderStatus verification failed");
-      return StatusCode::Error;
+      return PoolPtr<OrderStatus>();
     }
     auto orderMsg = flatbuffers::GetRoot<gen::fbs::OrderStatus>(buffer);
-    return OrderStatus{0,
-                       orderMsg->id(),
-                       fbStringToTicker(orderMsg->ticker()),
-                       orderMsg->quantity(),
-                       orderMsg->fill_price(),
-                       convert(orderMsg->state()),
-                       convert(orderMsg->action())};
+    auto statusPtr = PoolPtr<OrderStatus>::create();
+    statusPtr->id = orderMsg->id();
+    statusPtr->ticker = fbStringToTicker(orderMsg->ticker());
+    statusPtr->quantity = orderMsg->quantity();
+    statusPtr->fillPrice = orderMsg->fill_price();
+    statusPtr->state = convert(orderMsg->state());
+    statusPtr->action = convert(orderMsg->action());
+    return statusPtr;
   }
 
   template <typename MessageType>
-  static std::enable_if_t<std::is_same<MessageType, TickerPrice>::value, Result<TickerPrice>>
+  static std::enable_if_t<std::is_same<MessageType, PoolPtr<TickerPrice>>::value,
+                          PoolPtr<TickerPrice>>
   deserialize(const uint8_t *buffer, size_t size) {
     flatbuffers::Verifier verifier(buffer, size);
     if (!verifier.VerifyBuffer<gen::fbs::TickerPrice>()) {
       spdlog::error("TickerPrice verification failed");
-      return StatusCode::Error;
+      return PoolPtr<TickerPrice>();
     }
     auto orderMsg = flatbuffers::GetRoot<gen::fbs::TickerPrice>(buffer);
-    return TickerPrice{fbStringToTicker(orderMsg->ticker()), orderMsg->price()};
+    auto pricePtr = PoolPtr<TickerPrice>::create();
+    pricePtr->ticker = fbStringToTicker(orderMsg->ticker());
+    pricePtr->price = orderMsg->price();
+    return pricePtr;
   }
 
-  static DetachedBuffer serialize(const Order &order) {
+  static DetachedBuffer serialize(const PoolPtr<Order> &order) {
     flatbuffers::FlatBufferBuilder builder;
-    auto msg = gen::fbs::CreateOrder(builder, order.id,
-                                     builder.CreateString(order.ticker.data(), TICKER_SIZE),
-                                     order.quantity, order.price, convert(order.action));
+    auto msg = gen::fbs::CreateOrder(builder, order->id,
+                                     builder.CreateString(order->ticker.data(), TICKER_SIZE),
+                                     order->quantity, order->price, convert(order->action));
     builder.Finish(msg);
     return builder.Release();
   }
 
-  static DetachedBuffer serialize(const OrderStatus &order) {
+  static DetachedBuffer serialize(const PoolPtr<OrderStatus> &order) {
     flatbuffers::FlatBufferBuilder builder;
     auto msg = gen::fbs::CreateOrderStatus(
-        builder, order.id, builder.CreateString(order.ticker.data(), TICKER_SIZE), order.quantity,
-        order.fillPrice, convert(order.state), convert(order.action));
+        builder, order->id, builder.CreateString(order->ticker.data(), TICKER_SIZE),
+        order->quantity, order->fillPrice, convert(order->state), convert(order->action));
     builder.Finish(msg);
     return builder.Release();
   }
 
-  static DetachedBuffer serialize(const TickerPrice &price) {
+  static DetachedBuffer serialize(const PoolPtr<TickerPrice> &price) {
     flatbuffers::FlatBufferBuilder builder;
     auto msg = gen::fbs::CreateTickerPrice(
-        builder, builder.CreateString(price.ticker.data(), TICKER_SIZE), price.price);
+        builder, builder.CreateString(price->ticker.data(), TICKER_SIZE), price->price);
     builder.Finish(msg);
     return builder.Release();
   }

--- a/common/src/types/market_types.hpp
+++ b/common/src/types/market_types.hpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <string_view>
 
+#include "pool/object_pool.hpp"
 #include "types.hpp"
 
 namespace hft {
@@ -45,6 +46,7 @@ struct Order {
   Price price;
   OrderAction action;
 };
+using PtrOrder = PoolPtr<Order>;
 
 struct OrderStatus {
   TraderId traderId; // Server side
@@ -55,11 +57,13 @@ struct OrderStatus {
   OrderState state;
   OrderAction action;
 };
+using PtrOrderStatus = PoolPtr<OrderStatus>;
 
 struct TickerPrice {
   Ticker ticker{};
   Price price;
 };
+using PtrTickerPrice = PoolPtr<TickerPrice>;
 
 } // namespace hft
 

--- a/common/src/types/template_types.hpp
+++ b/common/src/types/template_types.hpp
@@ -26,9 +26,13 @@ using Span = std::span<Type>;
 using Callback = std::function<void()>;
 using Predicate = std::function<bool()>;
 template <typename ArgType>
+using Handler = std::function<void(ArgType)>;
+template <typename ArgType>
 using CRefHandler = std::function<void(const ArgType &)>;
 template <typename ArgType>
 using SpanHandler = std::function<void(Span<ArgType>)>;
+template <typename ArgType>
+using MoveHandler = std::function<void(ArgType &&)>;
 
 template <typename EventType>
 using LFQueue = boost::lockfree::queue<EventType>;

--- a/run.sh
+++ b/run.sh
@@ -13,8 +13,8 @@ ulimit -c unlimited
 
 if [ "$1" == "s" ]; then
     rm -f server_log.*.txt
-    sudo ./hft_server
+    sudo ./server/hft_server
 else [ "$1" == "t" ];
     rm -f trader_log.*.txt
-    sudo ./hft_trader
+    sudo ./trader/hft_trader
 fi


### PR DESCRIPTION
Tried boost object pool for Order OrderStatus and TickerPrice creation and routing. Instead of copying the whole struct around we just copy the pointer and then reuse it. After some testing it turns out this object pooling approach is inefficient. Perhaps the size of the structs aint big enough or something. 

Current numbers for 5us trade rate:
03:39:22.150326 [I] Orders [matched|total] 3397337 4347169 rps:107305
03:39:21.890572 [I] RTT [<50us|<200us|>200us]  99.76% avg:15us  0.24% avg:72us  -

Numbers with object pooling:
03:40:41.088011 [I] Orders [matched|total] 1700505 2187352 rps:103095
03:40:41.290511 [I] RTT [<50us|<200us|>200us]  99.65% avg:18us  0.35% avg:76us  - 