### PR TITLE
Abstracted network layer for easy test mocking

### DIFF
--- a/client/src/network/network_client.hpp
+++ b/client/src/network/network_client.hpp
@@ -19,6 +19,7 @@
 #include "domain_types.hpp"
 #include "logging.hpp"
 #include "network/connection_status.hpp"
+#include "network/network_layer.hpp"
 #include "network/transport/tcp_transport.hpp"
 #include "network/transport/udp_transport.hpp"
 #include "types.hpp"
@@ -164,21 +165,21 @@ private:
 
 private:
   ClientTcpTransport createUpstreamTransport() {
-    return {utils::generateConnectionId(), TcpSocket{ioCtx_},
-            TcpEndpoint{Ip::make_address(ClientConfig::cfg.url), ClientConfig::cfg.portTcpUp},
+    return {utils::generateConnectionId(), NetworkFactory::createTcpSocket(ioCtx_),
+            NetworkFactory::createTcpEndpoint(ClientConfig::cfg.url, ClientConfig::cfg.portTcpUp),
             bus_};
   }
 
   ClientTcpTransport createDownstreamTransport() {
-    return {utils::generateConnectionId(), TcpSocket{ioCtx_},
-            TcpEndpoint{Ip::make_address(ClientConfig::cfg.url), ClientConfig::cfg.portTcpDown},
+    return {utils::generateConnectionId(), NetworkFactory::createTcpSocket(ioCtx_),
+            NetworkFactory::createTcpEndpoint(ClientConfig::cfg.url, ClientConfig::cfg.portTcpDown),
             bus_};
   }
 
   ClientUdpTransport createPricesTransport() {
     return {utils::generateConnectionId(),
-            utils::createUdpSocket(ioCtx_, false, ClientConfig::cfg.portUdp),
-            UdpEndpoint(Udp::v4(), ClientConfig::cfg.portUdp), bus_};
+            NetworkFactory::createUdpSocket(ioCtx_, false, ClientConfig::cfg.portUdp),
+            NetworkFactory::createUdpEndpoint(false, ClientConfig::cfg.portUdp), bus_};
   }
 
 private:

--- a/common/src/network/boost_network_layer.hpp
+++ b/common/src/network/boost_network_layer.hpp
@@ -1,0 +1,57 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-05-01
+ */
+
+#ifndef HFT_COMMON_BOOST_NETWORKLAYER_HPP
+#define HFT_COMMON_BOOST_NETWORKLAYER_HPP
+
+#include "boost_types.hpp"
+#include "types.hpp"
+
+namespace hft {
+
+namespace Ip = boost::asio::ip;
+
+using Tcp = boost::asio::ip::tcp;
+using TcpSocket = boost::asio::ip::tcp::socket;
+using TcpEndpoint = boost::asio::ip::tcp::endpoint;
+using TcpAcceptor = boost::asio::ip::tcp::acceptor;
+
+using Udp = boost::asio::ip::udp;
+using UdpSocket = boost::asio::ip::udp::socket;
+using UdpEndpoint = boost::asio::ip::udp::endpoint;
+
+class NetworkFactory {
+public:
+  /**
+   * Tcp
+   */
+  static TcpEndpoint createTcpEndpoint(Port port) { return TcpEndpoint{Tcp::v4(), port}; }
+  static TcpEndpoint createTcpEndpoint(CRef<String> url, Port port) {
+    return TcpEndpoint{Ip::make_address(url), port};
+  }
+  static TcpSocket createTcpSocket(IoCtx &ctx) { return TcpSocket(ctx); }
+  static TcpAcceptor createTcpAcceptor(IoCtx &ctx) { return TcpAcceptor(ctx); }
+
+  /**
+   * Udp
+   */
+  static UdpEndpoint createUdpEndpoint(bool broadcast, Port port) {
+    return broadcast ? UdpEndpoint{Ip::address_v4::broadcast(), port}
+                     : UdpEndpoint(Udp::v4(), port);
+  }
+  static UdpSocket createUdpSocket(IoCtx &ctx, bool broadcast = true, Port port = 0) {
+    UdpSocket socket(ctx, Udp::v4());
+    socket.set_option(boost::asio::socket_base::reuse_address{true});
+    if (broadcast) {
+      socket.set_option(boost::asio::socket_base::broadcast(true));
+    } else {
+      socket.bind(UdpEndpoint(Udp::v4(), port));
+    }
+    return socket;
+  }
+};
+} // namespace hft
+
+#endif // HFT_COMMON_BOOST_NETWORKLAYER_HPP

--- a/common/src/network/network_layer.hpp
+++ b/common/src/network/network_layer.hpp
@@ -1,0 +1,15 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-05-01
+ */
+
+#ifndef HFT_COMMON_NETWORKLAYER_HPP
+#define HFT_COMMON_NETWORKLAYER_HPP
+
+#ifndef UNIT_TEST
+#include "boost_network_layer.hpp"
+#else
+#include "mock_network_layer.hpp"
+#endif
+
+#endif // HFT_COMMON_NETWORKLAYER_HPP

--- a/common/src/network/transport/tcp_transport.hpp
+++ b/common/src/network/transport/tcp_transport.hpp
@@ -10,6 +10,7 @@
 #include "logging.hpp"
 #include "network/connection_status.hpp"
 #include "network/framing/fixed_size_framer.hpp"
+#include "network/network_layer.hpp"
 #include "network/ring_buffer.hpp"
 #include "types.hpp"
 #include "utils/string_utils.hpp"

--- a/common/src/network/transport/udp_transport.hpp
+++ b/common/src/network/transport/udp_transport.hpp
@@ -10,6 +10,7 @@
 #include "logging.hpp"
 #include "network/connection_status.hpp"
 #include "network/framing/fixed_size_framer.hpp"
+#include "network/network_layer.hpp"
 #include "network/ring_buffer.hpp"
 #include "types.hpp"
 

--- a/common/src/types/boost_types.hpp
+++ b/common/src/types/boost_types.hpp
@@ -13,44 +13,19 @@
 
 namespace hft {
 
-namespace Ip = boost::asio::ip;
-
 using IoCtx = boost::asio::io_context;
-using UPtrIoCtx = std::unique_ptr<boost::asio::io_context>;
 using ContextGuard = boost::asio::executor_work_guard<IoCtx::executor_type>;
-using UPtrContextGuard = std::unique_ptr<ContextGuard>;
+using MakeGuard = decltype(boost::asio::make_work_guard(std::declval<boost::asio::io_context &>()));
 
 using BoostErrorCode = boost::system::error_code;
 
 using SteadyTimer = boost::asio::steady_timer;
-using Seconds = boost::asio::chrono::seconds;
-using Milliseconds = boost::asio::chrono::milliseconds;
-using Microseconds = boost::asio::chrono::microseconds;
 
 using ConstBuffer = boost::asio::const_buffer;
 using MutableBuffer = boost::asio::mutable_buffer;
 
-using MakeGuard = decltype(boost::asio::make_work_guard(std::declval<boost::asio::io_context &>()));
-
 using LittleEndianByte = boost::endian::little_uint8_at;
 using LittleEndianUInt16 = boost::endian::little_uint16_at;
-
-using Port = uint16_t;
-
-namespace Ip = boost::asio::ip;
-using Tcp = boost::asio::ip::tcp;
-using TcpSocket = boost::asio::ip::tcp::socket;
-using TcpEndpoint = boost::asio::ip::tcp::endpoint;
-using TcpAcceptor = boost::asio::ip::tcp::acceptor;
-
-using Udp = boost::asio::ip::udp;
-using UdpSocket = boost::asio::ip::udp::socket;
-using UdpEndpoint = boost::asio::ip::udp::endpoint;
-
-using SocketCallback = std::function<void(const BoostErrorCode &, size_t)>;
-using SocketStatusCallback = std::function<void(const BoostErrorCode &)>;
-
-using MessageSize = uint16_t;
 
 } // namespace hft
 

--- a/common/src/types/types.hpp
+++ b/common/src/types/types.hpp
@@ -6,8 +6,6 @@
 #ifndef HFT_COMMON_TYPES_HPP
 #define HFT_COMMON_TYPES_HPP
 
-#include <spdlog/common.h>
-
 #include <cstdint>
 #include <expected>
 #include <map>
@@ -16,6 +14,8 @@
 #include <string>
 #include <thread>
 #include <vector>
+
+#include <spdlog/common.h>
 
 #include "constants.hpp"
 #include "status_code.hpp"
@@ -34,6 +34,12 @@ using Thread = std::jthread;
 using Timestamp = uint64_t;
 using LogLevel = spdlog::level::level_enum;
 using Token = uint64_t;
+using Port = uint16_t;
+using MessageSize = uint16_t;
+
+using Seconds = std::chrono::seconds;
+using Milliseconds = std::chrono::milliseconds;
+using Microseconds = std::chrono::microseconds;
 
 enum class State : uint8_t { On, Off, Error };
 
@@ -42,16 +48,12 @@ enum class State : uint8_t { On, Off, Error };
  */
 template <typename Type>
 using SPtr = std::shared_ptr<Type>;
-
 template <typename Type>
 using WPtr = std::weak_ptr<Type>;
-
 template <typename Type>
 using UPtr = std::unique_ptr<Type>;
-
 template <typename Type>
 using CRef = const Type &;
-
 template <typename Type>
 using Opt = std::optional<Type>;
 
@@ -61,13 +63,10 @@ using Opt = std::optional<Type>;
 template <typename Type>
 using Span = std::span<Type>;
 using ByteSpan = Span<uint8_t>;
-
 template <typename K, typename V>
 using HashMap = std::unordered_map<K, V>;
-
 template <typename Type>
 using Atomic = std::atomic<Type>;
-
 template <typename Type>
 using Expected = std::expected<Type, StatusCode>;
 

--- a/common/src/utils/utils.cpp
+++ b/common/src/utils/utils.cpp
@@ -122,17 +122,6 @@ std::string getScaleNs(size_t nanoSec) {
   return getScaleUs(nanoSec / 1000);
 }
 
-UdpSocket createUdpSocket(IoCtx &ctx, bool broadcast, Port port) {
-  UdpSocket socket(ctx, Udp::v4());
-  socket.set_option(boost::asio::socket_base::reuse_address{true});
-  if (broadcast) {
-    socket.set_option(boost::asio::socket_base::broadcast(true));
-  } else {
-    socket.bind(UdpEndpoint(Udp::v4(), port));
-  }
-  return socket;
-}
-
 OrderId generateOrderId() {
   static std::atomic_uint64_t counter = 0;
   return counter.fetch_add(1, std::memory_order_relaxed);

--- a/common/src/utils/utils.hpp
+++ b/common/src/utils/utils.hpp
@@ -39,8 +39,6 @@ std::string getScaleNs(size_t);
 
 void printRawBuffer(const uint8_t *buffer, size_t size);
 
-UdpSocket createUdpSocket(IoCtx &ctx, bool broadcast = true, Port port = 0);
-
 OrderId generateOrderId();
 ConnectionId generateConnectionId();
 Token generateToken();

--- a/server/src/network/broadcast_service.hpp
+++ b/server/src/network/broadcast_service.hpp
@@ -8,6 +8,7 @@
 
 #include "boost_types.hpp"
 #include "config/server_config.hpp"
+#include "network/network_layer.hpp"
 #include "network/transport/udp_transport.hpp"
 #include "types.hpp"
 
@@ -20,8 +21,8 @@ class BroadcastService {
 public:
   BroadcastService(IoCtx &ioCtx, Bus &bus)
       : ioCtx_{ioCtx}, bus_{bus},
-        udpTransport_{utils::generateConnectionId(), utils::createUdpSocket(ioCtx_),
-                      UdpEndpoint{Ip::address_v4::broadcast(), ServerConfig::cfg.portUdp}, bus_} {
+        udpTransport_{utils::generateConnectionId(), NetworkFactory::createUdpSocket(ioCtx_),
+                      NetworkFactory::createUdpEndpoint(true, ServerConfig::cfg.portUdp), bus_} {
     bus_.marketBus.setHandler<TickerPrice>([this](CRef<TickerPrice> p) { udpTransport_.write(p); });
   }
 

--- a/server/src/network/network_server.hpp
+++ b/server/src/network/network_server.hpp
@@ -6,15 +6,11 @@
 #ifndef HFT_SERVER_NETWORKSERVER_HPP
 #define HFT_SERVER_NETWORKSERVER_HPP
 
-#include <algorithm>
-#include <format>
-#include <memory>
-
 #include "boost_types.hpp"
 #include "broadcast_service.hpp"
 #include "config/server_config.hpp"
 #include "domain_types.hpp"
-#include "network/transport/udp_transport.hpp"
+#include "network/network_layer.hpp"
 #include "server_command.hpp"
 #include "server_events.hpp"
 #include "server_types.hpp"
@@ -72,7 +68,7 @@ public:
 
 private:
   void startUpstream() {
-    TcpEndpoint endpoint(Tcp::v4(), ServerConfig::cfg.portTcpUp);
+    TcpEndpoint endpoint = NetworkFactory::createTcpEndpoint(ServerConfig::cfg.portTcpUp);
     upstreamAcceptor_.open(endpoint.protocol());
     upstreamAcceptor_.set_option(boost::asio::socket_base::reuse_address(true));
     upstreamAcceptor_.bind(endpoint);
@@ -93,7 +89,7 @@ private:
   }
 
   void startDownstream() {
-    TcpEndpoint endpoint(Tcp::v4(), ServerConfig::cfg.portTcpDown);
+    TcpEndpoint endpoint = NetworkFactory::createTcpEndpoint(ServerConfig::cfg.portTcpDown);
     downstreamAcceptor_.open(endpoint.protocol());
     downstreamAcceptor_.set_option(boost::asio::socket_base::reuse_address(true));
     downstreamAcceptor_.bind(endpoint);

--- a/server/src/network/session_channel.hpp
+++ b/server/src/network/session_channel.hpp
@@ -8,6 +8,7 @@
 
 #include "boost_types.hpp"
 #include "logging.hpp"
+#include "network/network_layer.hpp"
 #include "network/transport/tcp_transport.hpp"
 #include "server_types.hpp"
 #include "types.hpp"

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -5,6 +5,8 @@ file(GLOB_RECURSE COMMON_TEST_SOURCES
 
 add_executable(test_common_unit ${COMMON_TEST_SOURCES})
 
+target_compile_definitions(test_common_unit PRIVATE UNIT_TEST)
+
 target_link_libraries(test_common_unit 
     PRIVATE
     GTest::gtest


### PR DESCRIPTION
- For simplicity network types as well as factory to create them are defined in a boost network layer header
- Generic network layer header includes concrete implementation and real types are used 
- For tests generic network layer header includes mocked network layer with mocks for all network types and network factory to create them