### PR TITLE
Reworked network abstractions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # Skip this job if this is a pull request AND it's still a draft
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+
     services:
       postgres:
         image: postgres:15

--- a/common/src/network/concepts/network_layerable.hpp
+++ b/common/src/network/concepts/network_layerable.hpp
@@ -1,0 +1,48 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-07-27
+ */
+
+#ifndef HFT_COMMON_NETWORKLAYERABLE_HPP
+#define HFT_COMMON_NETWORKLAYERABLE_HPP
+
+#include <concepts>
+
+#include "network_listenerable.hpp"
+#include "tcp_transportable.hpp"
+#include "udp_transportable.hpp"
+
+namespace hft {
+
+/**
+ * @brief Defines a network layer templated by the bus type and listener type
+ * @details Network layer and listener are co-dependent: listener is accepting concrete transport
+ * types defined by the network layer, but network layer should be able to accept concrete listeners
+ * So network layer is required to expose tcp and udp transport types, that listener is required to
+ * accept, and network layer is required to accept listener.
+ * Connections are not routed via the bus, as its a message router with no bond between
+ * producer and consumer. New connections should be handled explicitly and strictly.
+ */
+template <template <typename, typename> typename NetworkLayer, typename BusType, typename Listener>
+concept NetworkLayerable =
+    Busable<BusType> &&
+    TcpTransportable<typename NetworkLayer<BusType, Listener>::TcpTransportType> &&
+    UdpTransportable<typename NetworkLayer<BusType, Listener>::UdpTransportType> &&
+    NetworkListenerable<Listener, typename NetworkLayer<BusType, Listener>::TcpTransportType> &&
+    requires(NetworkLayer<BusType, Listener> &network, BusType &bus, Listener &listener,
+             CRef<String> url, Port port, bool broadcast) {
+      { NetworkLayer<BusType, Listener>{bus, listener} };
+      {
+        network.createTcp(url, port)
+      } -> std::same_as<typename NetworkLayer<BusType, Listener>::TcpTransportType>;
+      {
+        network.createUdp(port, broadcast)
+      } -> std::same_as<typename NetworkLayer<BusType, Listener>::UdpTransportType>;
+      { network.listen(port) } -> std::same_as<void>;
+      { network.start() } -> std::same_as<void>;
+      { network.stop() } -> std::same_as<void>;
+    };
+
+} // namespace hft
+
+#endif // HFT_COMMON_NETWORKLAYERABLE_HPP

--- a/common/src/network/concepts/network_listenerable.hpp
+++ b/common/src/network/concepts/network_listenerable.hpp
@@ -1,0 +1,29 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-08-02
+ */
+
+#include <concepts>
+
+#include "tcp_transportable.hpp"
+#include "types.hpp"
+#include "udp_transportable.hpp"
+
+#ifndef HFT_COMMON_NETWORKLISTENERABLE_HPP
+#define HFT_COMMON_NETWORKLISTENERABLE_HPP
+
+namespace hft {
+
+/**
+ * @brief Defines a listener concept, that shall accept incoming network connections
+ */
+template <typename ListenerType, typename TcpTransportType>
+concept NetworkListenerable = // format
+    TcpTransportable<TcpTransportType> &&
+    requires(ListenerType &listener, TcpTransportType &&tcpTransport) {
+      { listener.acceptTcp(tcpTransport) } -> std::same_as<void>;
+    };
+
+} // namespace hft
+
+#endif // HFT_COMMON_NETWORKLISTENERABLE_HPP

--- a/common/src/network/concepts/tcp_transportable.hpp
+++ b/common/src/network/concepts/tcp_transportable.hpp
@@ -1,0 +1,31 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-07-27
+ */
+
+#ifndef HFT_COMMON_TCPTRANSPORTABLE_HPP
+#define HFT_COMMON_TCPTRANSPORTABLE_HPP
+
+#include <concepts>
+
+#include "concepts/busable.hpp"
+#include "domain_types.hpp"
+#include "network/connection_status.hpp"
+
+namespace hft {
+
+template <typename TcpTransportType>
+concept TcpTransportable =
+    Busable<TcpTransportType> && requires(TcpTransportType &chan, ClientId id) {
+      { chan.connectionId() } -> std::same_as<ConnectionId>;
+      { chan.connect() } -> std::same_as<void>;
+      { chan.read() } -> std::same_as<void>;
+      { chan.reconnect() } -> std::same_as<void>;
+      { chan.isConnected() } -> std::same_as<bool>;
+      { chan.status() } -> std::same_as<ConnectionStatus>;
+      { chan.close() } -> std::same_as<void>;
+    };
+
+} // namespace hft
+
+#endif // HFT_COMMON_TCPTRANSPORTABLE_HPP

--- a/common/src/network/concepts/udp_transportable.hpp
+++ b/common/src/network/concepts/udp_transportable.hpp
@@ -1,0 +1,26 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2025-07-27
+ */
+
+#ifndef HFT_COMMON_UDPTRANSPORTABLE_HPP
+#define HFT_COMMON_UDPTRANSPORTABLE_HPP
+
+#include <concepts>
+
+#include "concepts/busable.hpp"
+#include "domain_types.hpp"
+
+namespace hft {
+
+template <typename UdpTransportType>
+concept UdpTransportable =
+    Busable<UdpTransportType> && requires(UdpTransportType &chan, ClientId id) {
+      { chan.connectionId() } -> std::same_as<ConnectionId>;
+      { chan.read() } -> std::same_as<void>;
+      { chan.close() } -> std::same_as<void>;
+    };
+
+} // namespace hft
+
+#endif // HFT_COMMON_UDPTRANSPORTABLE_HPP


### PR DESCRIPTION
Current network concept abstractions are not as abstract as one could have hoped. It only abstracts the server side. Instead, there shall be an abstraction, for network layer, that defines tcp connection, udp connection, and methods to create those, and subscribe to new incoming connections. And current SessionChannel should be server only.