### PR TITLE
Improved server benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Monitor:
 
 Benchmarks:
 ```bash
-2025-12-28T19:30:58+01:00
+2025-12-29T07:15:13+01:00
 Running ./run_benchmarks
 Run on (20 X 4600 MHz CPU s)
 CPU Caches:
@@ -103,26 +103,27 @@ CPU Caches:
   L1 Instruction 32 KiB (x10)
   L2 Unified 1280 KiB (x10)
   L3 Unified 24576 KiB (x1)
-Load Average: 1.60, 1.00, 0.40
-------------------------------------------------------------------------------------------------
-Benchmark                                      Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------
-BM_Sys_ServerFix/AsyncProcess_1Worker        291 ns          227 ns      8388608
-BM_Sys_ServerFix/AsyncProcess_2Workers       267 ns          266 ns      8388608
-BM_Sys_ServerFix/AsyncProcess_3Workers       358 ns          357 ns      8388608
-BM_Sys_ServerFix/AsyncProcess_4Workers       459 ns          458 ns      8388608
-BM_Ser_ProtoSerialize                        182 ns          182 ns      3736254
-BM_Ser_ProtoDeserialize                      133 ns          133 ns      5200438
-BM_Ser_FbsSerialize                          150 ns          150 ns      5359374
-BM_Ser_FbsDeserialize                       31.6 ns         31.6 ns     21990438
-BM_Ser_SbeSerialize                         2.43 ns         2.42 ns    288539113
-BM_Ser_SbeDeserialize                       11.7 ns         11.7 ns     63787435
-BM_Sys_OrderBookFix/AddOrder                99.9 ns         99.9 ns      6959726
-BM_Op_VykovMpmcQueue                        14.1 ns         14.1 ns     49494243
-BM_Op_FollyMpmcQueue                        48.5 ns         48.5 ns     14495449
-BM_Op_BoostMpmcQueue                        36.0 ns         36.0 ns     19423840
-BM_Op_MessageBusPost                        2.07 ns         2.07 ns    342791320
-BM_Op_SystemBusPost                          240 ns          236 ns      3088693
+Load Average: 1.45, 1.48, 1.50
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+--------------------------------------------------------------------------
+Benchmark                                Time             CPU   Iterations
+--------------------------------------------------------------------------
+BM_Sys_ServerFix/AsyncProcess/1        274 ns          271 ns      8388608 1 worker(s)
+BM_Sys_ServerFix/AsyncProcess/2        232 ns          231 ns      8388608 2 worker(s)
+BM_Sys_ServerFix/AsyncProcess/3        264 ns          264 ns      8388608 3 worker(s)
+BM_Sys_ServerFix/AsyncProcess/4        313 ns          312 ns      8388608 4 worker(s)
+BM_Ser_ProtoSerialize                  155 ns          155 ns      4703107
+BM_Ser_ProtoDeserialize                106 ns          106 ns      6239428
+BM_Ser_FbsSerialize                    127 ns          127 ns      5884048
+BM_Ser_FbsDeserialize                 27.4 ns         25.9 ns     28605473
+BM_Ser_SbeSerialize                   4.07 ns         3.93 ns    171509780
+BM_Ser_SbeDeserialize                 13.7 ns         13.3 ns     53795182
+BM_Sys_OrderBookFix/AddOrder           116 ns          115 ns      5887201
+BM_Op_VykovMpmcQueue                  13.4 ns         13.4 ns     49638099
+BM_Op_FollyMpmcQueue                  43.7 ns         43.7 ns     15873203
+BM_Op_BoostMpmcQueue                  34.3 ns         34.3 ns     20681295
+BM_Op_MessageBusPost                  1.79 ns         1.79 ns    397134516
+BM_Op_SystemBusPost                    217 ns          215 ns      3198985
 ```
 
 Stress test (Server + Python tester with 5m pregenerated orders):

--- a/benchmarks/src/bench_main.cpp
+++ b/benchmarks/src/bench_main.cpp
@@ -14,7 +14,5 @@ int main(int argc, char **argv) {
     return 1;
   ::benchmark::RunSpecifiedBenchmarks();
 
-  hft::benchmarks::BM_Sys_ServerFix::GlobalTearDown();
-
   return 0;
 }

--- a/benchmarks/src/bench_server.hpp
+++ b/benchmarks/src/bench_server.hpp
@@ -7,6 +7,7 @@
 #define HFT_BENCHSERVER_HPP
 
 #include <benchmark/benchmark.h>
+#include <iostream>
 
 #include "adapters/postgres/postgres_adapter.hpp"
 #include "commands/server_command.hpp"
@@ -23,30 +24,31 @@ namespace hft::benchmarks {
 class BM_Sys_ServerFix : public benchmark::Fixture {
 public:
   BM_Sys_ServerFix();
+  ~BM_Sys_ServerFix();
 
-  inline static std::once_flag initFlag;
-  inline static UPtr<server::MarketData> data;
-  inline static UPtr<server::ServerBus> bus;
-  inline static UPtr<server::Coordinator> coordinator;
+  UPtr<server::ServerBus> bus;
 
-  inline static size_t tickerCount{10};
-  inline static size_t workerCount{1};
-  inline static size_t orderLimit{ORDER_BOOK_LIMIT};
+  size_t tickerCount{10};
+  size_t workerCount{1};
+  size_t orderLimit{ORDER_BOOK_LIMIT};
 
-  inline static std::vector<Ticker> tickers;
-  inline static std::vector<server::ServerOrder> orders;
+  std::vector<Ticker> tickers;
+  server::MarketData marketData;
+  std::vector<server::ServerOrder> orders;
 
-  inline static std::jthread systemThread;
-  inline static std::atomic_flag flag{ATOMIC_FLAG_INIT};
+  UPtr<server::Coordinator> coordinator;
 
-  static void GlobalSetUp();
-  static void GlobalTearDown();
+  std::atomic_flag flag{ATOMIC_FLAG_INIT};
+  std::jthread systemThread;
 
-  static void setupBus();
-  static void setupCoordinator();
+  void SetUp(const ::benchmark::State &state) override;
+  void TearDown(const ::benchmark::State &state) override;
 
-  static void fillMarketData();
-  static void fillOrders();
+  void setupBus();
+  void fillMarketData();
+  void setupCoordinator();
+  void fillOrders();
+  void cleanup();
 };
 
 } // namespace hft::benchmarks

--- a/common/src/config/config.hpp
+++ b/common/src/config/config.hpp
@@ -30,7 +30,7 @@ struct Config {
   template <typename Type>
   static Type get(CRef<String> name) {
     if (data.empty()) {
-      throw std::runtime_error("Config has not been loaded");
+      throw std::runtime_error(std::format("Failed to get {}: config has not been loaded", name));
     }
     try {
       return data.get<Type>(name);

--- a/server/src/execution/coordinator.hpp
+++ b/server/src/execution/coordinator.hpp
@@ -120,7 +120,9 @@ private:
     timer_.expires_after(monitorRate_);
     timer_.async_wait([this](BoostErrorCode ec) {
       if (ec) {
-        LOG_ERROR_SYSTEM("Error {}", ec.message());
+        if (ec != ASIO_ERR_ABORTED) {
+          LOG_ERROR_SYSTEM("Error {}", ec.message());
+        }
         return;
       }
       static std::atomic_uint64_t lastTtl = 0;


### PR DESCRIPTION
- Added separate benchmarks for 1,2,3 and 4 workers
- Numbers improve drastically
- It now shows excellent scaling, 2 and 3 workers are faster then 1, and 4 workers just 10% slower
- Probably there is some contention on the counters, as all workers and the bench thread share them, but setting up separate counter would introduce some complexity too. Notification comes to the bus with order id, need to map it to ticker first, then map ticker to worker id, and in the end each workers counter would still be shared with benchmark thread, so maybe wont shave off alot of ns.
- Even though benchmark waits for Accepted status, and it is sent upon picking up the order, but before matching it, tested it with sending Ack after matching is done, with no difference. Workers wont pick up a new order before matching previous one. Workers may match order when loop is already processing new order for other worker though, but i guess noise is bigger then this difference. Also latency is dominated by the routing anyway, not matching, as running SystemBus::post benchmarks to 200ns under high load, which is io_ctx post, same as posting to workers.