### PR TITLE
Further benchmark improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Load Average: 1.45, 1.48, 1.50
 --------------------------------------------------------------------------
 Benchmark                                Time             CPU   Iterations
 --------------------------------------------------------------------------
-BM_Sys_ServerFix/AsyncProcess/1        196 ns          196 ns      8388608 1 worker(s)
-BM_Sys_ServerFix/AsyncProcess/2        111 ns          111 ns      8388608 2 worker(s)
-BM_Sys_ServerFix/AsyncProcess/3       87.6 ns         87.6 ns      8388608 3 worker(s)
-BM_Sys_ServerFix/AsyncProcess/4       97.7 ns         97.6 ns      8388608 4 worker(s)
+BM_Sys_ServerFix/AsyncProcess/1        124 ns          124 ns      6291456 1 worker(s)
+BM_Sys_ServerFix/AsyncProcess/2       71.1 ns         71.1 ns     10485760 2 worker(s)
+BM_Sys_ServerFix/AsyncProcess/3       49.2 ns         49.2 ns     14680064 3 worker(s)
+BM_Sys_ServerFix/AsyncProcess/4       43.9 ns         43.9 ns     14680064 4 worker(s)
 BM_Ser_ProtoSerialize                  155 ns          155 ns      4703107
 BM_Ser_ProtoDeserialize                106 ns          106 ns      6239428
 BM_Ser_FbsSerialize                    127 ns          127 ns      5884048

--- a/common/src/lfq_runner.hpp
+++ b/common/src/lfq_runner.hpp
@@ -27,7 +27,7 @@ namespace hft {
  * @brief
  */
 template <typename MessageType, typename Consumer>
-class LfqRunner {
+class alignas(64) LfqRunner {
   static constexpr size_t MAX_EMPTY_CYCLES = 1'000'000;
   static constexpr size_t CAPACITY = 2'097'152;
 

--- a/common/src/types/ticker.hpp
+++ b/common/src/types/ticker.hpp
@@ -23,8 +23,10 @@ inline Ticker makeTicker(const std::string &str) {
 }
 
 struct TickerHash {
-  std::size_t operator()(const Ticker &t) const {
-    return std::hash<std::string_view>{}(std::string_view(t.data(), t.size()));
+  std::size_t operator()(const Ticker &t) const noexcept {
+    uint32_t val;
+    std::memcpy(&val, t.data(), 4);
+    return static_cast<std::size_t>(val);
   }
 };
 

--- a/server/src/execution/coordinator.hpp
+++ b/server/src/execution/coordinator.hpp
@@ -58,7 +58,12 @@ class Coordinator {
       if (oData.orderBook.add(so, bus)) {
         oData.orderBook.match(bus);
       }
+#if defined(BENCHMARK_BUILD) || defined(UNIT_TESTS_BUILD)
+      oData.orderBook.sendAck(so, bus);
+#endif
+#ifdef TELEMETRY_ENABLED
       ordersTotal.fetch_add(1, std::memory_order_relaxed);
+#endif
     }
 
     ServerBus &bus;

--- a/server/src/execution/order_book.hpp
+++ b/server/src/execution/order_book.hpp
@@ -80,11 +80,14 @@ public:
     }
     openedOrders_.store(bids_.size() + asks_.size(), std::memory_order_relaxed);
 
-#if defined(BENCHMARK_BUILD) || defined(UNIT_TESTS_BUILD)
-    consumer.post(ServerOrderStatus{order.clientId, order.order.id, 0, 0, 0, OrderState::Accepted});
-#endif
     return true;
   }
+#if defined(BENCHMARK_BUILD) || defined(UNIT_TESTS_BUILD)
+  template <Busable Consumer>
+  void sendAck(CRef<ServerOrder> order, Consumer &consumer) {
+    consumer.post(ServerOrderStatus{order.clientId, order.order.id, 0, 0, 0, OrderState::Accepted});
+  }
+#endif
 
   template <Busable Consumer>
   void match(Consumer &consumer) {

--- a/server/src/server_types.hpp
+++ b/server/src/server_types.hpp
@@ -38,7 +38,7 @@ struct ServerLoginResponse {
   String error{""};
 };
 
-struct alignas(8) ServerOrder {
+struct ServerOrder {
   ClientId clientId;
   Order order;
 };

--- a/tests/unit/src/test_order_book.cpp
+++ b/tests/unit/src/test_order_book.cpp
@@ -55,6 +55,11 @@ public:
 
   template <typename EventType>
   void post(CRef<EventType>) {}
+
+  void addOrder(ServerOrder order) {
+    book->add(order, *this);
+    book->sendAck(order, *this);
+  }
 };
 
 template <>
@@ -70,13 +75,13 @@ TEST_F(OrderBookFixture, OrderBookLimitReqched) {
 }
 
 TEST_F(OrderBookFixture, OrdersWontMatch) {
-  book->add<OrderBookFixture>({cId(), {oId(), ts(), tkr, 1, 40, SELL}}, *this);
-  book->add({cId(), {oId(), ts(), tkr, 1, 50, SELL}}, *this);
-  book->add({cId(), {oId(), ts(), tkr, 1, 60, SELL}}, *this);
+  addOrder({cId(), {oId(), ts(), tkr, 1, 40, SELL}});
+  addOrder({cId(), {oId(), ts(), tkr, 1, 50, SELL}});
+  addOrder({cId(), {oId(), ts(), tkr, 1, 60, SELL}});
 
-  book->add({cId(), {oId(), ts(), tkr, 1, 30, BUY}}, *this);
-  book->add({cId(), {oId(), ts(), tkr, 1, 20, BUY}}, *this);
-  book->add({cId(), {oId(), ts(), tkr, 1, 10, BUY}}, *this);
+  addOrder({cId(), {oId(), ts(), tkr, 1, 30, BUY}});
+  addOrder({cId(), {oId(), ts(), tkr, 1, 20, BUY}});
+  addOrder({cId(), {oId(), ts(), tkr, 1, 10, BUY}});
 
   book->match(*this);
 
@@ -85,13 +90,13 @@ TEST_F(OrderBookFixture, OrdersWontMatch) {
 }
 
 TEST_F(OrderBookFixture, 3Buy3SellMatch) {
-  book->add({cId(), {oId(), ts(), tkr, 1, 40, BUY}}, *this);
-  book->add({cId(), {oId(), ts(), tkr, 1, 50, BUY}}, *this);
-  book->add({cId(), {oId(), ts(), tkr, 1, 60, BUY}}, *this);
+  addOrder({cId(), {oId(), ts(), tkr, 1, 40, BUY}});
+  addOrder({cId(), {oId(), ts(), tkr, 1, 50, BUY}});
+  addOrder({cId(), {oId(), ts(), tkr, 1, 60, BUY}});
 
-  book->add({cId(), {oId(), ts(), tkr, 1, 30, SELL}}, *this);
-  book->add({cId(), {oId(), ts(), tkr, 1, 20, SELL}}, *this);
-  book->add({cId(), {oId(), ts(), tkr, 1, 10, SELL}}, *this);
+  addOrder({cId(), {oId(), ts(), tkr, 1, 30, SELL}});
+  addOrder({cId(), {oId(), ts(), tkr, 1, 20, SELL}});
+  addOrder({cId(), {oId(), ts(), tkr, 1, 10, SELL}});
 
   book->match(*this);
 
@@ -104,11 +109,11 @@ TEST_F(OrderBookFixture, 10Buy1SellMatch) {
   Price price{10};
 
   for (uint32_t idx = 0; idx < 10; ++idx) {
-    book->add({cId(), {oId(), ts(), tkr, idx, price, BUY}}, *this);
+    addOrder({cId(), {oId(), ts(), tkr, idx, price, BUY}});
     quantity += idx;
   }
 
-  book->add({cId(), {oId(), ts(), tkr, quantity, price, SELL}}, *this);
+  addOrder({cId(), {oId(), ts(), tkr, quantity, price, SELL}});
   book->match(*this);
 
   printStatusQ();


### PR DESCRIPTION
- Removed atomic total order counter in hot paths (redundant and very expensive)
- Improved ticker hasher
- Reduced the number of orders for benchmarks (no need to use gigabytes of RAM for benchmarks)
- 43ns for internal order processing at the network borders under high load with 4 workers
- Almost perfect scaling 124ns->43ns 1->4 workers