### PR TITLE
Fixed trusted bus for type conversions

### DIFF
--- a/common/src/network/channel.hpp
+++ b/common/src/network/channel.hpp
@@ -69,7 +69,7 @@ public:
     }
     netBuff.setSize(Framer::frame(msg, netBuff.data()));
     auto dataSpan = netBuff.dataSpan();
-    LOG_DEBUG("sending {} bytes", dataSpan.size());
+    LOG_TRACE("sending {} bytes", dataSpan.size());
 
     transport_.asyncTx(dataSpan, [self = this->weak_from_this(),
                                   buff = std::move(netBuff)](IoResult code, size_t bytes) {

--- a/common/src/network/transport/shm/shm_transport.hpp
+++ b/common/src/network/transport/shm/shm_transport.hpp
@@ -80,6 +80,7 @@ public:
       }
     }
     if (closed_) {
+      LOG_DEBUG("already closed");
       return;
     }
     reactor_.notifyRemote();
@@ -110,7 +111,7 @@ public:
   }
 
   inline size_t tryDrain() noexcept {
-    LOG_DEBUG("ShmTransport tryDrain");
+    LOG_TRACE("ShmTransport tryDrain");
     if (closed_) {
       LOG_ERROR("Transport is already closed");
       if (rxArmed_.exchange(false, std::memory_order_acq_rel)) {
@@ -123,11 +124,13 @@ public:
     }
 
     if (!rxArmed_.load(std::memory_order_acquire)) {
+      LOG_WARN("unarmed");
       return 0;
     }
 
     const size_t bytes = buffer_.read(rxBuf_.data(), rxBuf_.size());
     if (bytes == 0) {
+      LOG_TRACE("no data");
       return 0;
     }
 

--- a/common/src/utils/sync_utils.hpp
+++ b/common/src/utils/sync_utils.hpp
@@ -25,10 +25,10 @@ inline void futexWake(Futex &futex, int count = 1) {
 
 inline void futexWait(Futex &futex, uint32_t curr, uint32_t timeout = 0) {
   if (timeout == 0) {
-    LOG_DEBUG("futexWait");
+    LOG_TRACE("futexWait {}", curr);
     syscall(SYS_futex, reinterpret_cast<uint32_t *>(&futex), FUTEX_WAIT, curr, nullptr, nullptr, 0);
   } else {
-    LOG_DEBUG("futexWait timed {}", timeout);
+    LOG_TRACE("futexWait timed {} {}", curr, timeout);
     struct timespec ts {
       .tv_sec = static_cast<time_t>(timeout / 1000),
       .tv_nsec = static_cast<long>((timeout % 1000) * 1000000)
@@ -38,7 +38,7 @@ inline void futexWait(Futex &futex, uint32_t curr, uint32_t timeout = 0) {
 }
 
 inline void hybridWait(Futex &futex, uint32_t curr, uint64_t spinCount = 10'000) {
-  LOG_DEBUG("hybridWait");
+  LOG_TRACE("hybridWait {}", curr);
   for (uint64_t i = 0; i < spinCount; ++i) {
     if (futex.load(std::memory_order_acquire) != curr)
       return;


### PR DESCRIPTION
Trusted session manager doesn't need SessionBus for authentication, so initially a bus restrictors were used directly with the channel. 
But then raw  Orders are coming through, unconverted to server side wrappers. 
Bit of a multiple responsibilities does SessionBus have, but stacking lots of bus wrappers is not a great idea.
Even though SessionBus does several things, its code is minimal.

BusRestrictor -> policy based bus
SessionBus -> protocol based bus