### PR TITLE
Reworked network buffer pool

### DIFF
--- a/client/config/client_config.ini
+++ b/client/config/client_config.ini
@@ -6,11 +6,11 @@ port_udp=8082
 
 [cpu]
 core_system=
-core_network=3
-cores_app=4
+core_network=6
+cores_app=7
 
 [rates]
-trade_rate_us=100
+trade_rate_us=15
 monitor_rate_ms=1000
 telemetry_ms=100
 warmup=10000
@@ -43,4 +43,3 @@ shm_upstream=/mnt/huge/hft_upstream
 shm_downstream=/mnt/huge/hft_downstream
 shm_broadcast=/mnt/huge/hft_broadcast
 shm_telemetry=/mnt/huge/hft_telemetry
-shm_size=8388608

--- a/monitor/config/monitor_config.ini
+++ b/monitor/config/monitor_config.ini
@@ -28,4 +28,3 @@ shm_upstream=/mnt/huge/hft_upstream
 shm_downstream=/mnt/huge/hft_downstream
 shm_broadcast=/mnt/huge/hft_broadcast
 shm_telemetry=/mnt/huge/hft_telemetry
-shm_size=8388608

--- a/server/config/server_config.ini
+++ b/server/config/server_config.ini
@@ -6,9 +6,9 @@ port_udp=8082
 
 [cpu]
 core_system=
-core_network=5
-core_gateway=6
-cores_app=7
+core_network=3
+core_gateway=4
+cores_app=5
 
 [rates]
 price_feed_rate_us=1000
@@ -41,4 +41,3 @@ shm_upstream=/mnt/huge/hft_upstream
 shm_downstream=/mnt/huge/hft_downstream
 shm_broadcast=/mnt/huge/hft_broadcast
 shm_telemetry=/mnt/huge/hft_telemetry
-shm_size=8388608

--- a/server/src/control_center.hpp
+++ b/server/src/control_center.hpp
@@ -54,10 +54,9 @@ namespace hft::server {
  * offloading it right away to another thread.
  * Network and gateway threads touch in the gateway. Ensuring they do not touch the same data
  * is done via thread safe id pool, network thread allocates the id, writes the record producing
- * InternalOrderEvent for the worker, and never touches that record again.
- * Gateway thread can access that record only when status notification comes from the worker,
- * and from that point it fully manages the record.
- * When order gets closed, id of the record gets returned to the pool
+ * InternalOrderEvent for the worker, and never touches that record, until its released to the pool.
+ * Gateway thread takes over that record when status notification comes from the worker,
+ * until order gets closed, when it releases id to the pool
  */
 class ControlCenter {
   using PricesChannel = Channel<DatagramTransport, DatagramBus>;


### PR DESCRIPTION
- reviewing old code found out previous ideas were not thread safe
- changed network buffer pool to use Vyukov queue for recycling indexes
- chunk of memory is indexed and indexes are recycled via lfq
- acquiring buffer pops from lfq, if its empty - spawns new chunk with index currentIdxCount++
- releasing buffer pushes into lfq
- buffers are spawned on demand, if network writes are fast, there be only a few buffers in use
- which is great for cache locality
- sync works cause ack/rel is a single operation on a queue, not two operations as before