### PR TITLE
Fixed thread safety of order records

### DIFF
--- a/benchmarks/src/bench_server.cpp
+++ b/benchmarks/src/bench_server.cpp
@@ -92,10 +92,15 @@ void BM_ServerFix::post(const ComponentReady &ev) {
 }
 
 void BM_ServerFix::post(CRef<InternalOrderStatus> s) {
+  // In the current flow only one status event is sent per order
+  // if order triggers fulfills with resting orders, single partial/full event is sent
+  // If order rests - accepted state event is sent
+  // resting orders never generate state events
   if (s.state == OrderState::Rejected) {
     error.store(true, std::memory_order_release);
     LOG_ERROR_SYSTEM("Increase OrderBook limit");
   } else {
+    // so all non-rejected events would give us overall processed orders count
     processed.fetch_add(1, std::memory_order_relaxed);
   }
 }

--- a/common/src/containers/batch_spsc.hpp
+++ b/common/src/containers/batch_spsc.hpp
@@ -1,0 +1,76 @@
+/**
+ * @author Vladimir Pavliv
+ * @date 2026-01-24
+ */
+
+#ifndef HFT_COMMON_BATCHSPSC_HPP
+#define HFT_COMMON_BATCHSPSC_HPP
+
+#include "primitive_types.hpp"
+
+namespace hft {
+
+template <typename T, size_t Capacity>
+class BatchSPSC {
+  static_assert(std::is_trivially_copyable_v<T>);
+  static_assert((Capacity & (Capacity - 1)) == 0);
+
+public:
+  static constexpr size_t MSG_SIZE = sizeof(T);
+  static constexpr size_t BUFFER_SIZE = Capacity * MSG_SIZE;
+
+  BatchSPSC() = default;
+
+  bool write(const T &msg) noexcept {
+    const size_t currentTail = tail_.load(std::memory_order_relaxed);
+
+    if (currentTail + MSG_SIZE > headCache_ + BUFFER_SIZE) {
+      headCache_ = head_.load(std::memory_order_acquire);
+      if (currentTail + MSG_SIZE > headCache_ + BUFFER_SIZE)
+        return false;
+    }
+
+    const size_t writePos = currentTail & (BUFFER_SIZE - 1);
+    std::memcpy(buffer_ + writePos, &msg, MSG_SIZE);
+
+    tail_.store(currentTail + MSG_SIZE, std::memory_order_release);
+    return true;
+  }
+
+  std::span<T> readBatch(size_t maxBatch = 64) noexcept {
+    const size_t currentHead = head_.load(std::memory_order_relaxed);
+    const size_t currentTail = tail_.load(std::memory_order_acquire);
+
+    if (currentHead == currentTail)
+      return {};
+
+    size_t headPos = currentHead & (BUFFER_SIZE - 1);
+
+    size_t bytesToEnd = BUFFER_SIZE - headPos;
+    size_t availableBytes = std::min(currentTail - currentHead, bytesToEnd);
+
+    size_t count = std::min(availableBytes / MSG_SIZE, maxBatch);
+    return {reinterpret_cast<T *>(buffer_ + headPos), count};
+  }
+
+  void commitRead(size_t count) noexcept {
+    if (count == 0) {
+      return;
+    }
+    size_t currentHead = head_.load(std::memory_order_relaxed);
+    head_.store(currentHead + (count * MSG_SIZE), std::memory_order_release);
+  }
+
+private:
+  ALIGN_CL AtomicSizeT head_{0};
+  size_t headCache_{0};
+
+  ALIGN_CL AtomicSizeT tail_{0};
+  size_t tailCache_{0};
+
+  ALIGN_CL uint8_t buffer_[BUFFER_SIZE];
+};
+
+} // namespace hft
+
+#endif // HFT_COMMON_BATCHSPSC_HPP

--- a/common/src/types/primitive_types.hpp
+++ b/common/src/types/primitive_types.hpp
@@ -48,6 +48,7 @@ using Atomic = std::atomic<T>;
 using AtomicBool = std::atomic<bool>;
 using AtomicUInt32 = std::atomic<uint32_t>;
 using AtomicUInt64 = std::atomic<uint64_t>;
+using AtomicSizeT = std::atomic<size_t>;
 using AtomicFlag = std::atomic_flag;
 
 enum class State : uint8_t { On, Off, Error };

--- a/common/src/utils/string_utils.hpp
+++ b/common/src/utils/string_utils.hpp
@@ -86,7 +86,7 @@ inline String formatCompact(uint64_t num) {
 
 /**
  * @brief Number thousandifier
- * @return Thousandified number. A number, that has gone through thousandification procedures
+ * @return A number, that has gone through thousandification procedures
  */
 template <std::integral T>
 std::string thousandify(T value) {

--- a/server/src/gateway/order_record.hpp
+++ b/server/src/gateway/order_record.hpp
@@ -7,16 +7,37 @@
 #define HFT_SERVER_ORDERRECORD_HPP
 
 #include "domain_types.hpp"
+#include "primitive_types.hpp"
 #include "schema.hpp"
 
 namespace hft::server {
+enum class RecordState : uint32_t { New, Accepted, Closed };
+
+/**
+ * @brief RecordState is made raw with atomic_ref access to keep record trivially constructible
+ */
 struct OrderRecord {
+  // Immutable after create
   OrderId externalOId;
   SystemOrderId systemOId;
   BookOrderId bookOId;
-
-  ClientId clientId;
   Ticker ticker;
+
+  // published once
+  ClientId clientId;
+
+  // lifecycle
+  RecordState state;
+
+  inline RecordState getState() const {
+    std::atomic_ref<const RecordState> aState(state);
+    return aState.load(std::memory_order_acquire);
+  }
+
+  inline void setState(RecordState newState) {
+    std::atomic_ref<RecordState> aState(state);
+    aState.store(newState, std::memory_order_release);
+  }
 };
 } // namespace hft::server
 


### PR DESCRIPTION
Normal order flow guarantees thread safe access to order records in OrderGateway from network and gateway threads. Network thread picks up the free slot id from atomic id pool, creates the record, publishes event, and never touches that record until order is closed and its id is returned to the pool.

But cancel/modify flow does require network thread to access order record while its active. So cancel/modify event could come right when order gets fulfilled.

To solve this:
- records are never cleaned up in the gateway thread or elsewhere
- instead record id just gets released to the pool, and atomic record state gets set to Closed
- network thread either sees the closed record ready for reuse
- or it picks up the record id, reuses it, and if cancel arrives late, it would fail, cause system id generation changed
- state in the record is non atomic to keep the record trivially constructible
- instead  get/set is done via methods using atomic_ref wrappers
- all other members never change while record could be accessed by both network and gateway threads
- so no need to make them atomic

Also added BatchSPSC, could potentially improve throughput, by processing whatever amount is available in the lock-free queue in one go, significantly reducing amount of atomic ops. Aint tested yet, could just replace the lfq in lfqrunner, and just accessing batch of events, and triggering a callback per event. Not the whole flow could process the whole batch of events, orders and statuses would branch on ticker and client id. So batching is mostly needed for lock free handover. 